### PR TITLE
Also use GNU install dirs for build tree

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,8 @@ project(sealtk
 include(CMakePackageConfigHelpers)
 include(GNUInstallDirs)
 
+set(sealtk_BUILD_LIBDIR "${PROJECT_BINARY_DIR}/${CMAKE_INSTALL_LIBDIR}")
+
 list(APPEND CMAKE_MODULE_PATH
   "${PROJECT_SOURCE_DIR}/cmake"
   "${PROJECT_SOURCE_DIR}/cmake/thirdparty"
@@ -49,7 +51,7 @@ add_subdirectory(sealtk)
 
 export(EXPORT sealtk
   NAMESPACE sealtk::
-  FILE "${PROJECT_BINARY_DIR}/lib/cmake/sealtk/sealtk-targets.cmake"
+  FILE "${sealtk_BUILD_LIBDIR}/cmake/sealtk/sealtk-targets.cmake"
   )
 
 install(EXPORT sealtk
@@ -60,20 +62,20 @@ install(EXPORT sealtk
   )
 
 write_basic_package_version_file(
-  "${PROJECT_BINARY_DIR}/lib/cmake/sealtk/sealtk-config-version.cmake"
+  "${sealtk_BUILD_LIBDIR}/cmake/sealtk/sealtk-config-version.cmake"
   VERSION ${PROJECT_VERSION}
   COMPATIBILITY SameMajorVersion
   )
 
 configure_package_config_file(
   "${PROJECT_SOURCE_DIR}/cmake/sealtk-config.cmake.in"
-  "${PROJECT_BINARY_DIR}/lib/cmake/sealtk/sealtk-config.cmake"
+  "${sealtk_BUILD_LIBDIR}/cmake/sealtk/sealtk-config.cmake"
   INSTALL_DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/sealtk"
   )
 
 install(FILES
-  "${PROJECT_BINARY_DIR}/lib/cmake/sealtk/sealtk-config.cmake"
-  "${PROJECT_BINARY_DIR}/lib/cmake/sealtk/sealtk-config-version.cmake"
+  "${sealtk_BUILD_LIBDIR}/cmake/sealtk/sealtk-config.cmake"
+  "${sealtk_BUILD_LIBDIR}/cmake/sealtk/sealtk-config-version.cmake"
   DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/sealtk"
   COMPONENT Development
   )

--- a/cmake/SEALTKUtils.cmake
+++ b/cmake/SEALTKUtils.cmake
@@ -62,9 +62,9 @@ function(sealtk_add_library name)
   add_library(sealtk::${suffix} ALIAS ${suffix})
 
   set_target_properties(${suffix} PROPERTIES
-    RUNTIME_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/bin"
-    LIBRARY_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/lib"
-    ARCHIVE_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/lib"
+    RUNTIME_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/${CMAKE_INSTALL_BINDIR}"
+    LIBRARY_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/${CMAKE_INSTALL_LIBDIR}"
+    ARCHIVE_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/${CMAKE_INSTALL_LIBDIR}"
     OUTPUT_NAME "sealtk_${suffix}"
     )
 
@@ -140,8 +140,10 @@ function(sealtk_add_kwiver_plugin name)
   add_library(sealtk::${suffix} ALIAS ${suffix})
 
   set_target_properties(${suffix} PROPERTIES
-    RUNTIME_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/lib/kwiver/modules"
-    LIBRARY_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/lib/kwiver/modules"
+    RUNTIME_OUTPUT_DIRECTORY
+      "${PROJECT_BINARY_DIR}/${CMAKE_INSTALL_LIBDIR}/kwiver/modules"
+    LIBRARY_OUTPUT_DIRECTORY
+      "${PROJECT_BINARY_DIR}/${CMAKE_INSTALL_LIBDIR}/kwiver/modules"
     OUTPUT_NAME "sealtk_${suffix}"
     PREFIX ""
     )
@@ -220,7 +222,7 @@ function(sealtk_add_executable name)
   add_executable(sealtk::${suffix} ALIAS ${suffix})
 
   set_target_properties(${suffix} PROPERTIES
-    RUNTIME_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/bin"
+    RUNTIME_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/${CMAKE_INSTALL_BINDIR}"
     )
 
   target_link_libraries(${suffix}

--- a/cmake/setup_KWIVER.bat.in
+++ b/cmake/setup_KWIVER.bat.in
@@ -3,4 +3,4 @@
 :: https://github.com/Kitware/seal-tk/blob/master/LICENSE for details.
 
 set KWIVER_PLUGIN_PATH=^
-  "@PROJECT_BINARY_DIR@/lib/kwiver/modules;%KWIVER_PLUGIN_PATH%"
+  "@sealtk_BUILD_LIBDIR@/kwiver/modules;%KWIVER_PLUGIN_PATH%"

--- a/cmake/setup_KWIVER.sh.in
+++ b/cmake/setup_KWIVER.sh.in
@@ -3,4 +3,5 @@
 # https://github.com/Kitware/seal-tk/blob/master/LICENSE for details.
 
 export KWIVER_PLUGIN_PATH=\
-"@PROJECT_BINARY_DIR@/lib/kwiver/modules:$KWIVER_PLUGIN_PATH"
+"@sealtk_BUILD_LIBDIR@/kwiver/modules"\
+"${KWIVER_PLUGIN_PATH:+:$KWIVER_PLUGIN_PATH}"


### PR DESCRIPTION
Modify the logic that controls where build artifacts are written to also use the GNU directories. This makes the build tree more consistent with the install tree.