### PR TITLE
Don't "leak" main window

### DIFF
--- a/sealtk/noaa/Main.cpp
+++ b/sealtk/noaa/Main.cpp
@@ -21,8 +21,8 @@ int main(int argc, char** argv)
 
   QApplication app{argc, argv};
 
-  auto* window = new sealtk::noaa::gui::Window;
-  window->show();
+  sealtk::noaa::gui::Window window;
+  window.show();
 
   return app.exec();
 }


### PR DESCRIPTION
Modify entry point to stack allocate the main window, rather than heap allocating it. This is important because the main window needs to be destroyed before (or at least, during) the destruction of the `QApplication`, or Bad Things (note [[1]](https://lists.qt-project.org/pipermail/interest/2019-March/032807.html) [[2]](https://lists.qt-project.org/pipermail/interest/2019-March/032817.html)) can happen.