### PR TITLE
Improve VideoSource API

### DIFF
--- a/sealtk/core/KwiverVideoSource.hpp
+++ b/sealtk/core/KwiverVideoSource.hpp
@@ -40,10 +40,11 @@ public:
     kwiver::vital::algo::detected_object_set_input_sptr const&
       detectedObjectSetInput);
 
-  QSet<kwiver::vital::timestamp::time_t> times() const override;
+  TimeMap<kwiver::vital::timestamp::frame_t> frames() const override;
 
 public slots:
-  void seek(kwiver::vital::timestamp::time_t time) override;
+  void seek(kwiver::vital::timestamp::time_t time, SeekMode mode) override;
+  void seekFrame(kwiver::vital::timestamp::frame_t frame);
   void invalidate() const override;
 
 protected:

--- a/sealtk/core/TimeMap.hpp
+++ b/sealtk/core/TimeMap.hpp
@@ -5,9 +5,12 @@
 #ifndef sealtk_core_TimeMap_hpp
 #define sealtk_core_TimeMap_hpp
 
-#include <QMap>
-
 #include <vital/types/timestamp.h>
+
+#include <qtEnumerate.h>
+
+#include <QMap>
+#include <QSet>
 
 namespace sealtk
 {
@@ -172,6 +175,19 @@ public:
 
   ~TimeMap()
   {
+  }
+
+  QSet<kwiver::vital::timestamp::time_t> keySet() const
+  {
+    auto out = QSet<kwiver::vital::timestamp::time_t>{};
+    out.reserve(this->size());
+
+    for (auto const& item : qtEnumerate(*this))
+    {
+      out.insert(item.key());
+    }
+
+    return out;
   }
 
   using QMap<kwiver::vital::timestamp::time_t, Value>::find;

--- a/sealtk/core/VideoSource.hpp
+++ b/sealtk/core/VideoSource.hpp
@@ -6,15 +6,15 @@
 #define sealtk_core_VideoSource_hpp
 
 #include <sealtk/core/Export.h>
-
-#include <QImage>
-#include <QObject>
-#include <QSet>
-#include <qtGlobal.h>
+#include <sealtk/core/TimeMap.hpp>
 
 #include <vital/types/detected_object_set.h>
 #include <vital/types/image_container.h>
-#include <vital/types/timestamp.h>
+
+#include <qtGlobal.h>
+
+#include <QImage>
+#include <QObject>
 
 namespace sealtk
 {
@@ -32,20 +32,24 @@ public:
   explicit VideoSource(QObject* parent = nullptr);
   ~VideoSource() override;
 
-  virtual QSet<kwiver::vital::timestamp::time_t> times() const = 0;
+  virtual TimeMap<kwiver::vital::timestamp::frame_t> frames() const = 0;
 
 signals:
-  void kwiverImageDisplayed(
-    kwiver::vital::image_container_sptr const& image) const;
-  void noImageDisplayed() const;
-  void detectedObjectSetDisplayed(
-    kwiver::vital::detected_object_set_sptr const& detetedObjectSet) const;
-  void noDetectedObjectSetDisplayed() const;
+  void imageReady(
+    kwiver::vital::image_container_sptr const& image,
+    kwiver::vital::timestamp const& timeStamp) const;
+  void detectionsReady(
+    kwiver::vital::detected_object_set_sptr const& detetedObjectSet,
+    kwiver::vital::timestamp const& timeStamp) const;
   void videoInputChanged() const;
 
 public slots:
   virtual void invalidate() const = 0;
-  virtual void seek(kwiver::vital::timestamp::time_t time) = 0;
+  virtual void seek(kwiver::vital::timestamp::time_t time, SeekMode mode) = 0;
+  virtual void seekFrame(kwiver::vital::timestamp::frame_t frame) = 0;
+
+  virtual void seekTime(kwiver::vital::timestamp::time_t time)
+  { seek(time, SeekExact); }
 
 protected:
   QTE_DECLARE_PRIVATE(VideoSource)

--- a/sealtk/core/test/KwiverVideoSource.cpp
+++ b/sealtk/core/test/KwiverVideoSource.cpp
@@ -43,7 +43,7 @@ private slots:
   void initTestCase();
   void init();
   void seek();
-  void times();
+  void frames();
   void cleanup();
 
 private:
@@ -94,27 +94,29 @@ void TestKwiverVideoSource::seek()
   };
 
   QVector<QImage> seekImages;
-  connect(this->videoSource.get(), &VideoSource::kwiverImageDisplayed,
+  connect(this->videoSource.get(), &VideoSource::imageReady,
           [&seekImages](kv::image_container_sptr const& image)
   {
-    seekImages.append(sealtk::core::imageContainerToQImage(image));
-  });
-  connect(this->videoSource.get(), &VideoSource::noImageDisplayed,
-          [&seekImages]()
-  {
-    seekImages.append(QImage{});
+    if (image)
+    {
+      seekImages.append(sealtk::core::imageContainerToQImage(image));
+    }
+    else
+    {
+      seekImages.append(QImage{});
+    }
   });
 
   for (auto t : seekTimes)
   {
-    this->videoSource->seek(t);
+    this->videoSource->seekTime(t);
   }
 
   QCOMPARE(seekImages.size(), seekFiles.size());
 
   for (int i = 0; i < seekFiles.size(); i++)
   {
-    if (!seekFiles[i].isNull())
+    if (!seekFiles[i].isEmpty())
     {
       QImage expected{sealtk::test::testDataPath(
         "KwiverVideoSource/" + seekFiles[i])};
@@ -128,13 +130,17 @@ void TestKwiverVideoSource::seek()
 }
 
 // ----------------------------------------------------------------------------
-void TestKwiverVideoSource::times()
+void TestKwiverVideoSource::frames()
 {
-  static QSet<kv::timestamp::time_t> const times{
-    1000, 2000, 3000, 4000, 5000,
+  static TimeMap<kv::timestamp::frame_t> const frames{
+    {1000, 1},
+    {2000, 2},
+    {3000, 3},
+    {4000, 4},
+    {5000, 5}
   };
 
-  QCOMPARE(this->videoSource->times(), times);
+  QCOMPARE(this->videoSource->frames(), frames);
 }
 
 }

--- a/sealtk/core/test/VideoController.cpp
+++ b/sealtk/core/test/VideoController.cpp
@@ -138,15 +138,17 @@ void TestVideoController::seek()
 
   for (int i = 0; i < 3; i++)
   {
-    connect(this->videoSources[i], &VideoSource::kwiverImageDisplayed,
+    connect(this->videoSources[i], &VideoSource::imageReady,
             [&seekImages, i](kv::image_container_sptr const& image)
     {
-      seekImages[i].append(sealtk::core::imageContainerToQImage(image));
-    });
-    connect(this->videoSources[i], &VideoSource::noImageDisplayed,
-            [&seekImages, i]()
-    {
-      seekImages[i].append(QImage{});
+      if (image)
+      {
+        seekImages[i].append(sealtk::core::imageContainerToQImage(image));
+      }
+      else
+      {
+        seekImages[i].append(QImage{});
+      }
     });
   }
 
@@ -200,15 +202,17 @@ void TestVideoController::removeVideoSource()
 
   for (int i = 0; i < 3; i++)
   {
-    connect(this->videoSources[i], &VideoSource::kwiverImageDisplayed,
+    connect(this->videoSources[i], &VideoSource::imageReady,
             [&seekImages, i](kv::image_container_sptr const& image)
     {
-      seekImages[i].append(sealtk::core::imageContainerToQImage(image));
-    });
-    connect(this->videoSources[i], &VideoSource::noImageDisplayed,
-            [&seekImages, i]()
-    {
-      seekImages[i].append(QImage{});
+      if (image)
+      {
+        seekImages[i].append(sealtk::core::imageContainerToQImage(image));
+      }
+      else
+      {
+        seekImages[i].append(QImage{});
+      }
     });
   }
 

--- a/sealtk/gui/Player.cpp
+++ b/sealtk/gui/Player.cpp
@@ -219,15 +219,10 @@ void Player::setVideoSource(core::VideoSource* videoSource)
 
     if (d->videoSource)
     {
-      connect(videoSource, &core::VideoSource::kwiverImageDisplayed,
+      connect(videoSource, &core::VideoSource::imageReady,
               this, &Player::setImage);
-      connect(videoSource, &core::VideoSource::noImageDisplayed,
-              [this](){ this->setImage(nullptr); });
-
-      connect(videoSource, &core::VideoSource::detectedObjectSetDisplayed,
+      connect(videoSource, &core::VideoSource::detectionsReady,
               this, &Player::setDetectedObjectSet);
-      connect(videoSource, &core::VideoSource::noDetectedObjectSetDisplayed,
-              [this](){ this->setDetectedObjectSet(nullptr); });
     }
 
     emit this->videoSourceSet(d->videoSource);

--- a/sealtk/noaa/test/ImageListVideoSourceFactory.cpp
+++ b/sealtk/noaa/test/ImageListVideoSourceFactory.cpp
@@ -120,20 +120,22 @@ void TestImageListVideoSourceFactory::loadVideoSource()
 
   QVector<QImage> seekImages;
 
-  connect(videoSource, &sealtk::core::VideoSource::kwiverImageDisplayed,
+  connect(videoSource, &sealtk::core::VideoSource::imageReady,
           [&seekImages](kv::image_container_sptr const& image)
   {
-    seekImages.append(sealtk::core::imageContainerToQImage(image));
-  });
-  connect(videoSource, &sealtk::core::VideoSource::noImageDisplayed,
-          [&seekImages]()
-  {
-    seekImages.append(QImage{});
+    if (image)
+    {
+      seekImages.append(sealtk::core::imageContainerToQImage(image));
+    }
+    else
+    {
+      seekImages.append(QImage{});
+    }
   });
 
   for (auto t : seekTimes)
   {
-    videoSource->seek(t);
+    videoSource->seekTime(t);
   }
 
   QCOMPARE(seekImages.size(), seekFiles.size());


### PR DESCRIPTION
Modify `VideoSource` to more explicitly work with a `TimeMap` for seeking, and to provide the complete `TimeMap` upon request rather than a `QSet` (which, as an unordered collection, is somewhat likely to be unhelpful on its own). Modify its signals to consolidate the cases where data is available and where data is not available, as we were not effectively making use of the latter as distinct from passing a null pointer via the former. Include the time stamp in these signals, which will be useful for users performing newly-possible inexact seeks. Modify `KwiverVideoSource` to accomodate these changes. Modify unit tests likewise.

This should help with certain use cases where sequential rather than random access is desired.

