### PR TITLE
Add "metadata" to video sources

### DIFF
--- a/sealtk/core/CMakeLists.txt
+++ b/sealtk/core/CMakeLists.txt
@@ -19,6 +19,7 @@ sealtk_add_library(sealtk::core
     KwiverVideoSource.cpp
     TimeStamp.cpp
     VideoController.cpp
+    VideoMetaData.cpp
     VideoSource.cpp
     VideoSourceFactory.cpp
 
@@ -32,6 +33,7 @@ sealtk_add_library(sealtk::core
     TimeMap.hpp
     TimeStamp.hpp
     VideoController.hpp
+    VideoMetaData.hpp
     VideoSource.hpp
     VideoSourceFactory.hpp
     "${SEALTK_CORE_VERSION_OUT}"

--- a/sealtk/core/VideoMetaData.cpp
+++ b/sealtk/core/VideoMetaData.cpp
@@ -1,0 +1,77 @@
+/* This file is part of SEAL-TK, and is distributed under the OSI-approved BSD
+ * 3-Clause License. See top-level LICENSE file or
+ * https://github.com/Kitware/seal-tk/blob/master/LICENSE for details. */
+
+#include <sealtk/core/VideoMetaData.hpp>
+
+namespace kv = kwiver::vital;
+
+namespace sealtk
+{
+
+namespace core
+{
+
+// ============================================================================
+class VideoMetaDataData : public QSharedData
+{
+public:
+  VideoMetaDataData(kv::timestamp const& ts, kv::path_t const& in)
+    : timeStamp{ts}, imageName{in}
+  {}
+
+  kv::timestamp timeStamp;
+  kv::path_t imageName;
+};
+
+QTE_IMPLEMENT_D_FUNC_SHARED(VideoMetaData)
+
+// ----------------------------------------------------------------------------
+VideoMetaData::VideoMetaData(kv::timestamp const& ts, kv::path_t const& in)
+  : d_ptr{new VideoMetaDataData{ts, in}}
+{
+}
+
+// ----------------------------------------------------------------------------
+VideoMetaData::~VideoMetaData()
+{
+}
+
+// ----------------------------------------------------------------------------
+VideoMetaData::VideoMetaData(VideoMetaData const&) = default;
+VideoMetaData::VideoMetaData(VideoMetaData&&) = default;
+VideoMetaData& VideoMetaData::operator=(VideoMetaData const&) = default;
+VideoMetaData& VideoMetaData::operator=(VideoMetaData&) = default;
+
+// ----------------------------------------------------------------------------
+kv::timestamp VideoMetaData::timeStamp() const
+{
+  QTE_D();
+  return d->timeStamp;
+}
+
+// ----------------------------------------------------------------------------
+kv::path_t VideoMetaData::imageName() const
+{
+  QTE_D();
+  return d->imageName;
+}
+
+// ----------------------------------------------------------------------------
+void VideoMetaData::setTimeStamp(kv::timestamp const& ts)
+{
+  QTE_D_DETACH();
+  d->timeStamp = ts;
+}
+
+
+// ----------------------------------------------------------------------------
+void VideoMetaData::setImageName(kv::path_t const& in)
+{
+  QTE_D_DETACH();
+  d->imageName = in;
+}
+
+} // namespace core
+
+} // namespace sealtk

--- a/sealtk/core/VideoMetaData.hpp
+++ b/sealtk/core/VideoMetaData.hpp
@@ -1,0 +1,52 @@
+/* This file is part of SEAL-TK, and is distributed under the OSI-approved BSD
+ * 3-Clause License. See top-level LICENSE file or
+ * https://github.com/Kitware/seal-tk/blob/master/LICENSE for details. */
+
+#ifndef sealtk_core_VideoMetaData_hpp
+#define sealtk_core_VideoMetaData_hpp
+
+#include <sealtk/core/Export.h>
+
+#include <vital/types/timestamp.h>
+#include <vital/vital_types.h>
+
+#include <qtGlobal.h>
+
+#include <QSharedDataPointer>
+
+namespace sealtk
+{
+
+namespace core
+{
+
+class VideoMetaDataData;
+
+class SEALTK_CORE_EXPORT VideoMetaData
+{
+public:
+  explicit VideoMetaData(kwiver::vital::timestamp const& timeStamp = {},
+                         kwiver::vital::path_t const& imageName = {});
+  ~VideoMetaData();
+
+  VideoMetaData(VideoMetaData const&);
+  VideoMetaData(VideoMetaData&&);
+  VideoMetaData& operator=(VideoMetaData const&);
+  VideoMetaData& operator=(VideoMetaData&);
+
+  kwiver::vital::timestamp timeStamp() const;
+  kwiver::vital::path_t imageName() const;
+
+  void setTimeStamp(kwiver::vital::timestamp const&);
+  void setImageName(kwiver::vital::path_t const&);
+
+private:
+  QTE_DECLARE_SHARED_PTR(VideoMetaData)
+  QTE_DECLARE_SHARED(VideoMetaData)
+};
+
+} // namespace core
+
+} // namespace sealtk
+
+#endif

--- a/sealtk/core/VideoSource.hpp
+++ b/sealtk/core/VideoSource.hpp
@@ -7,6 +7,7 @@
 
 #include <sealtk/core/Export.h>
 #include <sealtk/core/TimeMap.hpp>
+#include <sealtk/core/VideoMetaData.hpp>
 
 #include <vital/types/detected_object_set.h>
 #include <vital/types/image_container.h>
@@ -37,7 +38,7 @@ public:
 signals:
   void imageReady(
     kwiver::vital::image_container_sptr const& image,
-    kwiver::vital::timestamp const& timeStamp) const;
+    VideoMetaData const& metaData) const;
   void detectionsReady(
     kwiver::vital::detected_object_set_sptr const& detetedObjectSet,
     kwiver::vital::timestamp const& timeStamp) const;


### PR DESCRIPTION
Modify `VideoSource` to provide a new `VideoMetaData` instance along with the available image, rather than just a time stamp. This new class includes the time stamp, and will also include other information that is useful to the GUI (for now, also the image name).

We are using our own class here in order to also include the time stamp, which has providence separate from the metadata provided by the KWIVER `video_input`, and also because there is a bit of cognitive dissonance between the GUI's notion of metadata, which is generally frame-specific, and the KWIVER notion where metadata is a separate data stream independent of the frame images. However, in the future we may modify our class to also provide the raw KWIVER metadata.