### PR TITLE
Don't use QString::{to,from}StdString

### DIFF
--- a/sealtk/core/KwiverFileVideoSourceFactory.cpp
+++ b/sealtk/core/KwiverFileVideoSourceFactory.cpp
@@ -9,6 +9,8 @@
 
 #include <vital/algo/video_input.h>
 
+#include <qtStlUtil.h>
+
 namespace sealtk
 {
 
@@ -43,7 +45,7 @@ void KwiverFileVideoSourceFactory::loadFile(void* handle, QString const& path)
   kwiver::vital::algo::video_input_sptr vi;
   kwiver::vital::algo::video_input::set_nested_algo_configuration(
     "video_reader", this->config(path), vi);
-  vi->open(path.toStdString());
+  vi->open(stdString(path));
 
   auto* vs = new KwiverVideoSource{this->videoController()};
   vs->setVideoInput(vi);

--- a/sealtk/core/test/CMakeLists.txt
+++ b/sealtk/core/test/CMakeLists.txt
@@ -11,6 +11,7 @@ sealtk_add_library(sealtk::core_test_common
     TestCommon.cpp
 
   PRIVATE_LINK_LIBRARIES
+    qtExtensionsHeaders
     Qt5::Core
     kwiver::vital
     kwiver::vital_algo

--- a/sealtk/core/test/KwiverVideoSource.cpp
+++ b/sealtk/core/test/KwiverVideoSource.cpp
@@ -15,6 +15,8 @@
 
 #include <arrows/qt/image_container.h>
 
+#include <qtStlUtil.h>
+
 #include <QImage>
 #include <QSet>
 #include <QVector>
@@ -70,7 +72,7 @@ void TestKwiverVideoSource::init()
   kv::algo::video_input::set_nested_algo_configuration(
     "video_reader", this->config, videoReader);
   videoReader->open(
-    SEALTK_TEST_DATA_PATH("KwiverVideoSource/list.txt").toStdString());
+    stdString(SEALTK_TEST_DATA_PATH("KwiverVideoSource/list.txt")));
 
   this->videoSource = std::make_unique<core::KwiverVideoSource>();
   this->videoSource->setVideoInput(videoReader);

--- a/sealtk/core/test/TestCommon.cpp
+++ b/sealtk/core/test/TestCommon.cpp
@@ -6,6 +6,8 @@
 #include <vital/algo/image_io.h>
 #include <vital/plugin_loader/plugin_manager.h>
 
+#include <qtStlUtil.h>
+
 #include <QRegularExpression>
 
 namespace kv = kwiver::vital;
@@ -132,10 +134,10 @@ kv::metadata_sptr TimestampPassthrough::fixupMetadata(
     md = std::make_shared<kv::metadata>();
   }
 
-  auto match = regex.match(QString::fromStdString(filename));
+  auto match = regex.match(qtString(filename));
   if (match.hasMatch())
   {
-    std::istringstream is{match.captured(1).toStdString()};
+    std::istringstream is{stdString(match.captured(1))};
     kv::timestamp::time_t time;
     is >> time;
     kv::timestamp ts;

--- a/sealtk/core/test/VideoController.cpp
+++ b/sealtk/core/test/VideoController.cpp
@@ -16,6 +16,8 @@
 
 #include <arrows/qt/image_container.h>
 
+#include <qtStlUtil.h>
+
 #include <QImage>
 #include <QVector>
 
@@ -63,7 +65,7 @@ kv::algo::video_input_sptr TestVideoController::generateVideoInput(
   kv::algo::video_input_sptr vi;
   kv::algo::video_input::set_nested_algo_configuration(
     "video_reader", this->config, vi);
-  vi->open(path.toStdString());
+  vi->open(stdString(path));
   return vi;
 }
 

--- a/sealtk/noaa/gui/Window.cpp
+++ b/sealtk/noaa/gui/Window.cpp
@@ -18,11 +18,11 @@
 
 #include <sealtk/gui/SplitterWindow.hpp>
 
+#include <qtStlUtil.h>
+
 #include <QDockWidget>
 #include <QFileDialog>
 #include <QVector>
-
-#include <QtGlobal>
 
 #include <memory>
 
@@ -268,7 +268,7 @@ void WindowPrivate::createWindow(WindowData* data, QString const& title)
         kwiver::vital::algo::detected_object_set_input_sptr input;
         kwiver::vital::algo::detected_object_set_input
           ::set_nested_algo_configuration("input", config, input);
-        input->open(filename.toStdString());
+        input->open(stdString(filename));
         kwiverVideoSource->setDetectedObjectSetInput(input);
       }
     }


### PR DESCRIPTION
Avoid use of aforementioned methods, which assume that the `std::string` is / should be UTF-8. While this is almost certainly correct on Linux, it is almost as surely *wrong* on Windows. Instead, use the `qtString` and `stdString` functions from qtStlUtil which use `QString::{to,from}Local8Bit` under the hood.