### PR TITLE
Fix resource linking

### DIFF
--- a/sealtk/noaa/Main.cpp
+++ b/sealtk/noaa/Main.cpp
@@ -7,14 +7,11 @@
 
 #include <sealtk/noaa/gui/Window.hpp>
 
-#include <sealtk/gui/Resources.hpp>
-
 #include <vital/plugin_loader/plugin_manager.h>
 
 //-----------------------------------------------------------------------------
 int main(int argc, char** argv)
 {
-  sealtk::gui::Resources r;
   Q_INIT_RESOURCE(SEALTKBranding);
 
   kwiver::vital::plugin_manager::instance().load_all_plugins();


### PR DESCRIPTION
Remove reference to the library resources in the NOAA executable. This a) is completely unnecessary (`Q_INIT_RESOURCE` will declare the appropriate entry point) and b) breaks on Windows because the resource header references symbols which are not visible outside the library, leading to link errors.