### PR TITLE
Use homography

### DIFF
--- a/sealtk/gui/Player.cpp
+++ b/sealtk/gui/Player.cpp
@@ -72,8 +72,7 @@ public:
   kv::image_container_sptr image;
   kv::detected_object_set_sptr detectedObjectSet;
   std::vector<std::unique_ptr<QOpenGLBuffer>> detectedObjectVertexBuffers;
-  QMatrix3x3 homography;
-  QMatrix4x4 homographyGl;
+  QMatrix4x4 homography;
   QMatrix4x4 viewHomography;
 
   QOpenGLTexture imageTexture{QOpenGLTexture::Target2DArray};
@@ -180,28 +179,11 @@ void Player::setDetectedObjectSet(
 }
 
 //-----------------------------------------------------------------------------
-void Player::setHomography(QMatrix3x3 const& homography)
+void Player::setHomography(QMatrix4x4 const& homography)
 {
   QTE_D();
 
   d->homography = homography;
-  for (int row = 0; row < 3; row++)
-  {
-    for (int column = 0; column < 3; column++)
-    {
-      int glRow = row;
-      if (glRow >= 2)
-      {
-        glRow++;
-      }
-      int glColumn = column;
-      if (glColumn >= 2)
-      {
-        glColumn++;
-      }
-      d->homographyGl(glRow, glColumn) = d->homography(row, column);
-    }
-  }
   this->update();
 }
 
@@ -488,7 +470,6 @@ PlayerPrivate::PlayerPrivate(Player* parent)
   : q_ptr{parent}
 {
   this->homography.setToIdentity();
-  this->homographyGl.setToIdentity();
   this->viewHomography.setToIdentity();
 }
 
@@ -698,7 +679,7 @@ void PlayerPrivate::drawImage(float levelShift, float levelScale,
   this->imageShaderProgram.enableAttributeArray(1);
 
   this->imageShaderProgram.setUniformValueArray(this->imageHomographyLocation,
-                                                &this->homographyGl, 1);
+                                                &this->homography, 1);
   this->imageShaderProgram.setUniformValueArray(
     this->imageViewHomographyLocation, &this->viewHomography, 1);
 
@@ -727,7 +708,7 @@ void PlayerPrivate::drawDetections(QOpenGLFunctions* functions)
     this->detectionShaderProgram.enableAttributeArray(0);
 
     this->detectionShaderProgram.setUniformValueArray(
-      this->detectionHomographyLocation, &this->homographyGl, 1);
+      this->detectionHomographyLocation, &this->homography, 1);
     this->detectionShaderProgram.setUniformValueArray(
       this->detectionViewHomographyLocation, &this->viewHomography, 1);
 

--- a/sealtk/gui/Player.cpp
+++ b/sealtk/gui/Player.cpp
@@ -568,21 +568,9 @@ void PlayerPrivate::updateViewHomography()
   auto const bottom =
     static_cast<float>(this->center.y() + (0.5 * (ih + (vh / zoom))));
 
-  // Compute matrix scale and translation coefficients for x and y
-  auto const invX = 1.0f / (right - left);
-  auto const invY = 1.0f / (top - bottom);
-
-  auto const mxs = 2.0f * invX;
-  auto const mys = 2.0f * invY;
-  auto const mxt = -(right + left) * invX;
-  auto const myt = -(top + bottom) * invY;
-
-  this->viewHomography = QMatrix4x4{
-    mxs,  0.0f, 0.0f, mxt,
-    0.0f, mys,  0.0f, myt,
-    0.0f, 0.0f, 1.0f, 0.0f,
-    0.0f, 0.0f, 0.0f, 1.0f,
-  };
+  // Compute transform
+  this->viewHomography.setToIdentity();
+  this->viewHomography.ortho(left, right, bottom, top, 1.0, -1.0);
 
   q->update();
 }

--- a/sealtk/gui/Player.hpp
+++ b/sealtk/gui/Player.hpp
@@ -10,15 +10,16 @@
 
 #include <sealtk/core/VideoDistributor.hpp>
 
-#include <QMatrix3x3>
-#include <QOpenGLWidget>
-#include <QPointF>
-#include <qtGlobal.h>
-
 #include <vital/types/detected_object_set.h>
 #include <vital/types/image_container.h>
 
+#include <qtGlobal.h>
+
+#include <QOpenGLWidget>
+#include <QPointF>
+
 class QImage;
+class QMatrix4x4;
 
 namespace sealtk
 {
@@ -54,7 +55,7 @@ public slots:
                 sealtk::core::VideoMetaData const& metaData);
   void setDetectedObjectSet(
     kwiver::vital::detected_object_set_sptr const& detectedObjectSet);
-  void setHomography(QMatrix3x3 const& homography);
+  void setHomography(QMatrix4x4 const& homography);
   void setZoom(float zoom);
   void setCenter(QPointF center);
   void setVideoSource(core::VideoDistributor* videoSource);

--- a/sealtk/gui/Player.hpp
+++ b/sealtk/gui/Player.hpp
@@ -37,18 +37,23 @@ public:
   explicit Player(QWidget* parent = nullptr);
   ~Player() override;
 
-  Q_PROPERTY(float zoom READ zoom WRITE setZoom NOTIFY zoomChanged);
-  Q_PROPERTY(QPointF center READ center WRITE setCenter NOTIFY centerChanged);
+  Q_PROPERTY(float zoom READ zoom WRITE setZoom NOTIFY zoomChanged)
+  Q_PROPERTY(QPointF center READ center WRITE setCenter NOTIFY centerChanged)
+  Q_PROPERTY(QSize homographyImageSize
+             READ homographyImageSize
+             WRITE setHomographyImageSize)
   Q_PROPERTY(ContrastMode contrastMode READ contrastMode WRITE setContrastMode)
 
   float zoom() const;
   QPointF center() const;
   core::VideoDistributor* videoSource() const;
   ContrastMode contrastMode() const;
+  QSize homographyImageSize() const;
 
 signals:
   void zoomChanged(float zoom) const;
   void centerChanged(QPointF center) const;
+  void imageSizeChanged(QSize imageSize) const;
 
 public slots:
   virtual void setImage(kwiver::vital::image_container_sptr const& image,
@@ -56,6 +61,7 @@ public slots:
   virtual void setDetectedObjectSet(
     kwiver::vital::detected_object_set_sptr const& detectedObjectSet);
   void setHomography(QMatrix4x4 const& homography);
+  void setHomographyImageSize(QSize size);
   void setZoom(float zoom);
   void setCenter(QPointF center);
   void setVideoSource(core::VideoDistributor* videoSource);

--- a/sealtk/gui/Player.hpp
+++ b/sealtk/gui/Player.hpp
@@ -51,9 +51,9 @@ signals:
   void centerChanged(QPointF center) const;
 
 public slots:
-  void setImage(kwiver::vital::image_container_sptr const& image,
-                sealtk::core::VideoMetaData const& metaData);
-  void setDetectedObjectSet(
+  virtual void setImage(kwiver::vital::image_container_sptr const& image,
+                        sealtk::core::VideoMetaData const& metaData);
+  virtual void setDetectedObjectSet(
     kwiver::vital::detected_object_set_sptr const& detectedObjectSet);
   void setHomography(QMatrix4x4 const& homography);
   void setZoom(float zoom);

--- a/sealtk/noaa/gui/Player.cpp
+++ b/sealtk/noaa/gui/Player.cpp
@@ -6,12 +6,24 @@
 
 #include <sealtk/core/KwiverVideoSource.hpp>
 
+#include <vital/algo/transform_2d_io.h>
+#include <vital/exceptions/base.h>
+
+#include <qtStlUtil.h>
+
 #include <QAction>
 #include <QContextMenuEvent>
+#include <QFileDialog>
+#include <QMatrix4x4>
 #include <QMenu>
+#include <QMessageBox>
+#include <QTransform>
 
 #include <memory>
 #include <vector>
+
+namespace kv = kwiver::vital;
+namespace kva = kwiver::vital::algo;
 
 namespace sealtk
 {
@@ -27,18 +39,31 @@ class PlayerPrivate
 {
 public:
   std::vector<QAction*> videoSourceActions;
-  QAction* loadDetectionsAction;
+  QAction* loadTransformAction = nullptr;
+  QAction* loadDetectionsAction = nullptr;
+
+  kv::transform_2d_sptr transform;
+
+  void loadTransform(Player* q);
 };
 
 // ----------------------------------------------------------------------------
 QTE_IMPLEMENT_D_FUNC(Player)
 
 // ----------------------------------------------------------------------------
-Player::Player(QWidget* parent)
+Player::Player(Role role, QWidget* parent)
   : sealtk::gui::Player{parent},
     d_ptr{new PlayerPrivate}
 {
   QTE_D();
+
+  if (role == Role::Slave)
+  {
+    d->loadTransformAction = new QAction{"Load Transformation...", this};
+
+    connect(d->loadTransformAction, &QAction::triggered,
+            this, [this, d]{ d->loadTransform(this); });
+  }
 
   d->loadDetectionsAction = new QAction{"Load Detections...", this};
 
@@ -76,6 +101,43 @@ void Player::registerVideoSourceFactory(
 }
 
 // ----------------------------------------------------------------------------
+void Player::setImage(kv::image_container_sptr const& image,
+                      sealtk::core::VideoMetaData const& metaData)
+{
+  QTE_D();
+
+  sealtk::gui::Player::setImage(image, metaData);
+
+  if (image && d->transform)
+  {
+    auto const w = static_cast<qreal>(image->width());
+    auto const h = static_cast<qreal>(image->height());
+
+    QPolygonF in, out;
+    in.append({0, 0});
+    in.append({0, h});
+    in.append({w, h});
+    in.append({w, 0});
+
+    for (auto const& point : in)
+    {
+      auto const mappedPoint = d->transform->map({point.x(), point.y()});
+      out.append({mappedPoint.x(), mappedPoint.y()});
+    }
+
+    QTransform xf;
+    if (QTransform::quadToQuad(in, out, xf))
+    {
+      this->setHomography(xf);
+      return;
+    }
+  }
+
+  // Did not successfully set homography; use identity
+  this->setHomography({});
+}
+
+// ----------------------------------------------------------------------------
 void Player::contextMenuEvent(QContextMenuEvent* event)
 {
   QTE_D();
@@ -88,9 +150,50 @@ void Player::contextMenuEvent(QContextMenuEvent* event)
     submenu->addAction(action);
   }
 
+  if (d->loadTransformAction)
+  {
+    menu->addAction(d->loadTransformAction);
+  }
   menu->addAction(d->loadDetectionsAction);
 
   menu->exec(event->globalPos());
+}
+
+// ----------------------------------------------------------------------------
+void PlayerPrivate::loadTransform(Player* q)
+{
+  auto const& path = QFileDialog::getOpenFileName(q);
+  if (!path.isEmpty())
+  {
+    auto config = kv::config_block::empty_config();
+    config->set_value("transform_reader:type", "itk");
+
+    try
+    {
+      kva::transform_2d_io_sptr ti;
+      kva::transform_2d_io::set_nested_algo_configuration(
+        "transform_reader", config, ti);
+      if (ti)
+      {
+        this->transform = ti->load(stdString(path));
+      }
+      else
+      {
+        QMessageBox::warning(
+          q, QStringLiteral("Failed to load transformation"),
+          QStringLiteral("The transformation could not be loaded: "
+                         "a required plugin was not found"));
+      }
+    }
+    catch (kv::vital_exception const& e)
+    {
+      auto const& text =
+        QStringLiteral("The transformation could not be loaded: ") +
+        QString::fromLocal8Bit(e.what());
+      QMessageBox::warning(
+        q, QStringLiteral("Failed to load transformation"), text);
+    }
+  }
 }
 
 } // namespace gui

--- a/sealtk/noaa/gui/Player.cpp
+++ b/sealtk/noaa/gui/Player.cpp
@@ -43,8 +43,10 @@ public:
   QAction* loadDetectionsAction = nullptr;
 
   kv::transform_2d_sptr transform;
+  QSizeF imageSize;
 
   void loadTransform(Player* q);
+  void updateTransform(Player* q);
 };
 
 // ----------------------------------------------------------------------------
@@ -108,33 +110,17 @@ void Player::setImage(kv::image_container_sptr const& image,
 
   sealtk::gui::Player::setImage(image, metaData);
 
-  if (image && d->transform)
+  if (image)
   {
     auto const w = static_cast<qreal>(image->width());
     auto const h = static_cast<qreal>(image->height());
-
-    QPolygonF in, out;
-    in.append({0, 0});
-    in.append({0, h});
-    in.append({w, h});
-    in.append({w, 0});
-
-    for (auto const& point : in)
-    {
-      auto const mappedPoint = d->transform->map({point.x(), point.y()});
-      out.append({mappedPoint.x(), mappedPoint.y()});
-    }
-
-    QTransform xf;
-    if (QTransform::quadToQuad(in, out, xf))
-    {
-      this->setHomography(xf);
-      return;
-    }
+    d->imageSize = QSizeF{w, h};
+    d->updateTransform(this);
   }
-
-  // Did not successfully set homography; use identity
-  this->setHomography({});
+  else
+  {
+    d->imageSize = QSizeF{};
+  }
 }
 
 // ----------------------------------------------------------------------------
@@ -176,6 +162,7 @@ void PlayerPrivate::loadTransform(Player* q)
       if (ti)
       {
         this->transform = ti->load(stdString(path));
+        this->updateTransform(q);
       }
       else
       {
@@ -194,6 +181,38 @@ void PlayerPrivate::loadTransform(Player* q)
         q, QStringLiteral("Failed to load transformation"), text);
     }
   }
+}
+
+// ----------------------------------------------------------------------------
+void PlayerPrivate::updateTransform(Player* q)
+{
+  if (this->imageSize.isValid() && this->transform)
+  {
+    auto const w = this->imageSize.width();
+    auto const h = this->imageSize.height();
+
+    QPolygonF in, out;
+    in.append({0, 0});
+    in.append({0, h});
+    in.append({w, h});
+    in.append({w, 0});
+
+    for (auto const& point : in)
+    {
+      auto const mappedPoint = this->transform->map({point.x(), point.y()});
+      out.append({mappedPoint.x(), mappedPoint.y()});
+    }
+
+    QTransform xf;
+    if (QTransform::quadToQuad(in, out, xf))
+    {
+      q->setHomography(xf);
+      return;
+    }
+  }
+
+  // Did not successfully set homography; use identity
+  q->setHomography({});
 }
 
 } // namespace gui

--- a/sealtk/noaa/gui/Player.hpp
+++ b/sealtk/noaa/gui/Player.hpp
@@ -29,12 +29,21 @@ class SEALTK_NOAA_GUI_EXPORT Player : public sealtk::gui::Player
   Q_OBJECT
 
 public:
-  explicit Player(QWidget* parent = nullptr);
+  enum class Role
+  {
+    Master,
+    Slave,
+  };
+
+  explicit Player(Role role, QWidget* parent = nullptr);
   ~Player() override;
 
   void registerVideoSourceFactory(QString const& name,
                                   sealtk::core::VideoSourceFactory* factory,
                                   void* handle);
+
+  void setImage(kwiver::vital::image_container_sptr const& image,
+                sealtk::core::VideoMetaData const& metaData) override;
 
 signals:
   void loadDetectionsTriggered() const;
@@ -48,10 +57,10 @@ private:
   QTE_DECLARE_PRIVATE_RPTR(Player)
 };
 
-}
+} // gui
 
-}
+} // noaa
 
-}
+} // sealtk
 
 #endif

--- a/sealtk/noaa/gui/Window.cpp
+++ b/sealtk/noaa/gui/Window.cpp
@@ -25,6 +25,7 @@
 #include <qtStlUtil.h>
 
 #include <QCollator>
+#include <QDebug>
 #include <QDockWidget>
 #include <QFileDialog>
 #include <QMessageBox>
@@ -59,7 +60,8 @@ public:
   void registerVideoSourceFactory(
     QString const& name, sealtk::core::VideoSourceFactory* factory);
 
-  void createWindow(WindowData* data, QString const& title);
+  void createWindow(WindowData* data, QString const& title,
+                    sealtk::noaa::gui::Player::Role role);
 
   void executePipeline(QString const& pipelineFile);
 
@@ -89,8 +91,11 @@ Window::Window(QWidget* parent)
   QTE_D();
   d->ui.setupUi(this);
 
-  d->createWindow(&d->eoWindow, QStringLiteral("EO Imagery"));
-  d->createWindow(&d->irWindow, QStringLiteral("IR Imagery"));
+  constexpr auto Master = sealtk::noaa::gui::Player::Role::Master;
+  constexpr auto Slave = sealtk::noaa::gui::Player::Role::Slave;
+
+  d->createWindow(&d->eoWindow, QStringLiteral("EO Imagery"), Master);
+  d->createWindow(&d->irWindow, QStringLiteral("IR Imagery"), Slave);
 
   d->eoWindow.player->setContrastMode(::sealtk::gui::ContrastMode::Manual);
   d->irWindow.player->setContrastMode(::sealtk::gui::ContrastMode::Percentile);
@@ -249,12 +254,13 @@ void WindowPrivate::registerVideoSourceFactory(
 }
 
 //-----------------------------------------------------------------------------
-void WindowPrivate::createWindow(WindowData* data, QString const& title)
+void WindowPrivate::createWindow(WindowData* data, QString const& title,
+                                 sealtk::noaa::gui::Player::Role role)
 {
   QTE_Q();
 
   data->window = new sealtk::gui::SplitterWindow{q};
-  data->player = new sealtk::noaa::gui::Player{data->window};
+  data->player = new sealtk::noaa::gui::Player{role, data->window};
   data->window->setCentralWidget(data->player);
   data->window->setClosable(false);
   data->window->setWindowTitle(title);

--- a/sealtk/noaa/gui/Window.cpp
+++ b/sealtk/noaa/gui/Window.cpp
@@ -101,6 +101,9 @@ Window::Window(QWidget* parent)
   d->irWindow.player->setContrastMode(::sealtk::gui::ContrastMode::Percentile);
   d->irWindow.player->setPercentiles(0.0, 1.0);
 
+  connect(d->eoWindow.player, &::sealtk::gui::Player::imageSizeChanged,
+          d->irWindow.player, &::sealtk::gui::Player::setHomographyImageSize);
+
   d->videoController = make_unique<sealtk::core::VideoController>(this);
   d->ui.control->setVideoController(d->videoController.get());
 


### PR DESCRIPTION
Modify `noaa::gui::Player` to have a notion of a "master" window and "slave" windows, with the latter able to use a transformation to map their local space to the "master"'s space. Implement logic to allow the user to load such a transformation.

This uses a `vital::transform` (note: depends on kitware/kwiver#790) under the hood, which can include non-linear transformations. Eventually we want to handle those better; for now, we approximate by computing a homography matrix by mapping our image corner points.

This is a "static" transformation in that the user loads a single transformation for the entire data set (as opposed to having a separate transformation per frame). Eventually we will probably want to add support for per-frame transformations as well, which will likely rely on the video source to provide the transformation.