### PR TITLE
New video API

### DIFF
--- a/sealtk/core/CMakeLists.txt
+++ b/sealtk/core/CMakeLists.txt
@@ -19,7 +19,10 @@ sealtk_add_library(sealtk::core
     KwiverVideoSource.cpp
     TimeStamp.cpp
     VideoController.cpp
+    VideoDistributor.cpp
     VideoMetaData.cpp
+    VideoRequest.cpp
+    VideoRequestor.cpp
     VideoSource.cpp
     VideoSourceFactory.cpp
 
@@ -33,7 +36,11 @@ sealtk_add_library(sealtk::core
     TimeMap.hpp
     TimeStamp.hpp
     VideoController.hpp
+    VideoDistributor.hpp
+    VideoFrame.hpp
     VideoMetaData.hpp
+    VideoProvider.hpp
+    VideoRequest.hpp
     VideoSource.hpp
     VideoSourceFactory.hpp
     "${SEALTK_CORE_VERSION_OUT}"

--- a/sealtk/core/FileVideoSourceFactory.cpp
+++ b/sealtk/core/FileVideoSourceFactory.cpp
@@ -17,7 +17,7 @@ public:
 };
 
 // ----------------------------------------------------------------------------
-FileVideoSourceFactory::FileVideoSourceFactory(VideoController* parent)
+FileVideoSourceFactory::FileVideoSourceFactory(QObject* parent)
   : VideoSourceFactory{parent},
     d_ptr{new FileVideoSourceFactoryPrivate}
 {

--- a/sealtk/core/FileVideoSourceFactory.hpp
+++ b/sealtk/core/FileVideoSourceFactory.hpp
@@ -19,7 +19,6 @@ namespace sealtk
 namespace core
 {
 
-class VideoController;
 class VideoSource;
 
 class FileVideoSourceFactoryPrivate;
@@ -29,7 +28,7 @@ class SEALTK_CORE_EXPORT FileVideoSourceFactory : public VideoSourceFactory
   Q_OBJECT
 
 public:
-  explicit FileVideoSourceFactory(VideoController* parent = nullptr);
+  explicit FileVideoSourceFactory(QObject* parent = nullptr);
   ~FileVideoSourceFactory() override;
 
   virtual bool expectsDirectory() const;

--- a/sealtk/core/KwiverFileVideoSourceFactory.cpp
+++ b/sealtk/core/KwiverFileVideoSourceFactory.cpp
@@ -5,7 +5,6 @@
 #include <sealtk/core/KwiverFileVideoSourceFactory.hpp>
 
 #include <sealtk/core/KwiverVideoSource.hpp>
-#include <sealtk/core/VideoController.hpp>
 
 #include <vital/algo/video_input.h>
 
@@ -27,8 +26,7 @@ public:
 QTE_IMPLEMENT_D_FUNC(KwiverFileVideoSourceFactory)
 
 // ----------------------------------------------------------------------------
-KwiverFileVideoSourceFactory::KwiverFileVideoSourceFactory(
-  VideoController* parent)
+KwiverFileVideoSourceFactory::KwiverFileVideoSourceFactory(QObject* parent)
   : FileVideoSourceFactory{parent},
     d_ptr{new KwiverFileVideoSourceFactoryPrivate}
 {
@@ -45,12 +43,13 @@ void KwiverFileVideoSourceFactory::loadFile(void* handle, QString const& path)
   kwiver::vital::algo::video_input_sptr vi;
   kwiver::vital::algo::video_input::set_nested_algo_configuration(
     "video_reader", this->config(path), vi);
-  vi->open(stdString(path));
+  if (vi)
+  {
+    vi->open(stdString(path));
 
-  auto* vs = new KwiverVideoSource{this->videoController()};
-  vs->setVideoInput(vi);
-  this->videoController()->addVideoSource(vs);
-  emit this->videoSourceLoaded(handle, vs);
+    auto* vs = new KwiverVideoSource{vi, this->parent()};
+    emit this->videoSourceLoaded(handle, vs);
+  }
 }
 
 }

--- a/sealtk/core/KwiverFileVideoSourceFactory.hpp
+++ b/sealtk/core/KwiverFileVideoSourceFactory.hpp
@@ -21,18 +21,17 @@ namespace sealtk
 namespace core
 {
 
-class VideoController;
 class VideoSource;
 
 class KwiverFileVideoSourceFactoryPrivate;
 
-class SEALTK_CORE_EXPORT KwiverFileVideoSourceFactory :
-  public FileVideoSourceFactory
+class SEALTK_CORE_EXPORT KwiverFileVideoSourceFactory
+  : public FileVideoSourceFactory
 {
   Q_OBJECT
 
 public:
-  explicit KwiverFileVideoSourceFactory(VideoController* parent = nullptr);
+  explicit KwiverFileVideoSourceFactory(QObject* parent = nullptr);
   ~KwiverFileVideoSourceFactory() override;
 
 public slots:

--- a/sealtk/core/KwiverVideoSource.cpp
+++ b/sealtk/core/KwiverVideoSource.cpp
@@ -5,6 +5,9 @@
 #include <sealtk/core/KwiverVideoSource.hpp>
 
 #include <sealtk/core/TimeMap.hpp>
+#include <sealtk/core/VideoFrame.hpp>
+#include <sealtk/core/VideoProvider.hpp>
+#include <sealtk/core/VideoRequest.hpp>
 
 #include <arrows/qt/image_container.h>
 
@@ -45,178 +48,73 @@ kv::path_t getImageName(kv::metadata_vector const& mdv)
 } // namespace <anonymous>
 
 // ============================================================================
-class KwiverVideoSourcePrivate
+class KwiverVideoSourcePrivate : public VideoProvider
 {
 public:
+  KwiverVideoSourcePrivate(KwiverVideoSource* q) : q_ptr{q} {}
+
+  void initialize() override;
+  kv::timestamp processRequest(
+    VideoRequest&& request, kv::timestamp const& lastTime) override;
+
   kv::algo::video_input_sptr videoInput;
   TimeMap<frame_t> timestampMap;
 
-  kv::image_container_sptr image;
-  kv::timestamp timeStamp;
-  kv::path_t imageName;
+  // CAUTION: Members below this line are owned by the UI thread!
+  TimeMap<frame_t> externalTimestampMap;
+  bool ready = false;
 
-  QHash<frame_t, kv::detected_object_set_sptr> detectedObjectSets;
-
-  void rebuildTimestampMap();
+private:
+  QTE_DECLARE_PUBLIC_PTR(VideoSource)
+  QTE_DECLARE_PUBLIC(VideoSource)
 };
 
 // ----------------------------------------------------------------------------
 QTE_IMPLEMENT_D_FUNC(KwiverVideoSource)
 
 // ----------------------------------------------------------------------------
-KwiverVideoSource::KwiverVideoSource(QObject* parent)
-  : VideoSource{parent},
-    d_ptr{new KwiverVideoSourcePrivate}
+KwiverVideoSource::KwiverVideoSource(
+  kv::algo::video_input_sptr const& videoInput, QObject* parent)
+  : KwiverVideoSource{new KwiverVideoSourcePrivate{this}, parent}
+{
+  QTE_D();
+  d->videoInput = videoInput;
+}
+
+// ----------------------------------------------------------------------------
+KwiverVideoSource::KwiverVideoSource(
+  KwiverVideoSourcePrivate* d, QObject* parent)
+  : VideoSource{d, parent}, d_ptr{d}
 {
 }
 
 // ----------------------------------------------------------------------------
 KwiverVideoSource::~KwiverVideoSource()
 {
+  this->cleanup();
 }
 
 // ----------------------------------------------------------------------------
-kv::algo::video_input_sptr KwiverVideoSource::videoInput() const
+bool KwiverVideoSource::isReady() const
 {
   QTE_D();
-  return d->videoInput;
-}
-
-// ----------------------------------------------------------------------------
-void KwiverVideoSource::setVideoInput(
-  kv::algo::video_input_sptr const& videoInput)
-{
-  QTE_D();
-
-  d->videoInput = videoInput;
-  d->image = nullptr;
-  d->timeStamp = {};
-  d->imageName = {};
-
-  d->rebuildTimestampMap();
-
-  emit this->videoInputChanged();
-}
-
-// ----------------------------------------------------------------------------
-void KwiverVideoSource::setDetectedObjectSetInput(
-  kv::algo::detected_object_set_input_sptr const& detectedObjectSetInput)
-{
-  QTE_D();
-  d->detectedObjectSets.clear();
-
-  if (detectedObjectSetInput)
-  {
-    auto set = kv::detected_object_set_sptr{};
-    auto frame = frame_t{0};
-    auto imageName = std::string{};
-
-    while (detectedObjectSetInput->read_set(set, imageName))
-    {
-      if (set)
-      {
-        d->detectedObjectSets.insert(frame, set);
-      }
-      ++frame;
-    }
-  }
-
-  this->invalidate();
+  return d->ready;
 }
 
 // ----------------------------------------------------------------------------
 TimeMap<frame_t> KwiverVideoSource::frames() const
 {
   QTE_D();
-  return d->timestampMap;
+  return d->externalTimestampMap;
 }
 
 // ----------------------------------------------------------------------------
-void KwiverVideoSource::seek(kv::timestamp::time_t time, SeekMode mode)
+void KwiverVideoSourcePrivate::initialize()
 {
-  QTE_D();
-  auto const iter = d->timestampMap.find(time, mode);
-  if (iter != d->timestampMap.end())
-  {
-    if (d->videoInput->seek_frame(d->timeStamp, iter.value()))
-    {
-      Q_ASSERT(d->timeStamp.has_valid_time());
-      Q_ASSERT(d->timeStamp.has_valid_frame());
-      Q_ASSERT(d->timeStamp.get_time_usec() == iter.key());
-      Q_ASSERT(d->timeStamp.get_frame() == iter.value());
-      d->image = d->videoInput->frame_image();
-      d->imageName = getImageName(d->videoInput->frame_metadata());
-    }
-    else
-    {
-      // This should never happen
-      qWarning()
-        << this << __func__
-        << "underlying video source failed to seek to frame" << iter.value()
-        << "with expected time" << iter.key();
-      d->imageName = {};
-      d->timeStamp = {};
-      d->image = nullptr;
-    }
-  }
-  else
-  {
-    d->imageName = {};
-    d->timeStamp = {};
-    d->image = nullptr;
-  }
-
-  this->invalidate();
-}
-
-// ----------------------------------------------------------------------------
-void KwiverVideoSource::seekFrame(frame_t frame)
-{
-  QTE_D();
-
-  if (d->videoInput->seek_frame(d->timeStamp, frame))
-  {
-    Q_ASSERT(d->timeStamp.has_valid_frame());
-    Q_ASSERT(d->timeStamp.get_frame() == frame);
-    d->image = d->videoInput->frame_image();
-    d->imageName = getImageName(d->videoInput->frame_metadata());
-  }
-  else
-  {
-    d->imageName = {};
-    d->timeStamp = {};
-    d->image = nullptr;
-  }
-
-  invalidate();
-}
-
-// ----------------------------------------------------------------------------
-void KwiverVideoSource::invalidate() const
-{
-  QTE_D();
-
-  emit imageReady(d->image, VideoMetaData{d->timeStamp, d->imageName});
-
-  if (d->timeStamp.has_valid_frame())
-  {
-    auto const& detections =
-      d->detectedObjectSets.value(d->timeStamp.get_frame());
-    emit detectionsReady(detections, d->timeStamp);
-  }
-  else
-  {
-    emit detectionsReady(nullptr, d->timeStamp);
-  }
-}
-
-// ----------------------------------------------------------------------------
-void KwiverVideoSourcePrivate::rebuildTimestampMap()
-{
-  this->timestampMap.clear();
-
   if (this->videoInput)
   {
+    QTE_Q();
+
     kv::timestamp ts;
 
     for (auto const i : kvr::iota(videoInput->num_frames()))
@@ -226,10 +124,62 @@ void KwiverVideoSourcePrivate::rebuildTimestampMap()
       {
         Q_ASSERT(ts.has_valid_frame());
         Q_ASSERT(ts.get_frame() == frame);
-        timestampMap.insert(ts.get_time_usec(), ts.get_frame());
+
+        this->timestampMap.insert(ts.get_time_usec(), ts.get_frame());
       }
     }
+
+    QMetaObject::invokeMethod(q, [this, q, map = this->timestampMap]{
+      this->externalTimestampMap = map;
+      this->ready = true;
+      emit q->framesChanged();
+    });
   }
+}
+
+// ----------------------------------------------------------------------------
+kv::timestamp KwiverVideoSourcePrivate::processRequest(
+  VideoRequest&& request, kv::timestamp const& lastTime)
+{
+  auto const iter = this->timestampMap.find(request.time, request.mode);
+  if (iter != this->timestampMap.end())
+  {
+    if (lastTime.has_valid_time() &&
+        lastTime.get_time_usec() == iter.key())
+    {
+      return {};
+    }
+
+    kv::timestamp ts;
+    if (this->videoInput->seek_frame(ts, iter.value()))
+    {
+      Q_ASSERT(ts.has_valid_time());
+      Q_ASSERT(ts.has_valid_frame());
+      Q_ASSERT(ts.get_time_usec() == iter.key());
+      Q_ASSERT(ts.get_frame() == iter.value());
+
+      VideoFrame response;
+      response.image =this->videoInput->frame_image();
+      response.metaData.setTimeStamp(ts);
+      response.metaData.setImageName(
+        getImageName(this->videoInput->frame_metadata()));
+
+      request.sendReply(std::move(response));
+
+      return ts;
+    }
+    else
+    {
+      // This should never happen
+      qWarning()
+        << this << __func__
+        << "underlying video source failed to seek to frame" << iter.value()
+        << "with expected time" << iter.key();
+      return {};
+    }
+  }
+
+  return {};
 }
 
 }

--- a/sealtk/core/KwiverVideoSource.hpp
+++ b/sealtk/core/KwiverVideoSource.hpp
@@ -31,26 +31,20 @@ class SEALTK_CORE_EXPORT KwiverVideoSource : public VideoSource
   Q_OBJECT
 
 public:
-  explicit KwiverVideoSource(QObject* parent = nullptr);
+  explicit KwiverVideoSource(
+    kwiver::vital::algo::video_input_sptr const& videoInput,
+    QObject* parent = nullptr);
   ~KwiverVideoSource() override;
 
-  kwiver::vital::algo::video_input_sptr videoInput() const;
-  void setVideoInput(kwiver::vital::algo::video_input_sptr const& videoInput);
-  void setDetectedObjectSetInput(
-    kwiver::vital::algo::detected_object_set_input_sptr const&
-      detectedObjectSetInput);
-
+  bool isReady() const override;
   TimeMap<kwiver::vital::timestamp::frame_t> frames() const override;
-
-public slots:
-  void seek(kwiver::vital::timestamp::time_t time, SeekMode mode) override;
-  void seekFrame(kwiver::vital::timestamp::frame_t frame);
-  void invalidate() const override;
 
 protected:
   QTE_DECLARE_PRIVATE(KwiverVideoSource)
 
 private:
+  explicit KwiverVideoSource(KwiverVideoSourcePrivate* d, QObject* parent);
+
   QTE_DECLARE_PRIVATE_RPTR(KwiverVideoSource)
 };
 

--- a/sealtk/core/TimeMap.hpp
+++ b/sealtk/core/TimeMap.hpp
@@ -86,6 +86,7 @@ public:
   TimeMap& operator=(TimeMap const&) = default;
 
   QSet<Key> keySet() const;
+  TimeMap<std::nullptr_t> keyMap() const;
 
   using QMap<Key, Value>::find;
   using QMap<Key, Value>::constFind;
@@ -113,6 +114,20 @@ QSet<kwiver::vital::timestamp::time_t> TimeMap<Value>::keySet() const
   for (auto const& item : qtEnumerate(*this))
   {
     out.insert(item.key());
+  }
+
+  return out;
+}
+
+// ----------------------------------------------------------------------------
+template <typename Value>
+TimeMap<std::nullptr_t> TimeMap<Value>::keyMap() const
+{
+  auto out = TimeMap<std::nullptr_t>{};
+
+  for (auto const& item : qtEnumerate(*this))
+  {
+    out.insert(item.key(), nullptr);
   }
 
   return out;

--- a/sealtk/core/VideoController.cpp
+++ b/sealtk/core/VideoController.cpp
@@ -5,9 +5,16 @@
 #include <sealtk/core/VideoController.hpp>
 
 #include <sealtk/core/TimeMap.hpp>
+#include <sealtk/core/VideoDistributor.hpp>
+#include <sealtk/core/VideoRequest.hpp>
+#include <sealtk/core/VideoRequestor.hpp>
 #include <sealtk/core/VideoSource.hpp>
 
-#include <QSet>
+#include <sealtk/util/unique.hpp>
+
+#include <qtGet.h>
+
+#include <unordered_map>
 
 namespace sealtk
 {
@@ -19,10 +26,17 @@ namespace core
 class VideoControllerPrivate
 {
 public:
-  QSet<VideoSource*> videoSources;
-  kwiver::vital::timestamp::time_t time;
+  void updateTimes();
 
-  void rebuildTimes();
+  using time_t = kwiver::vital::timestamp::time_t;
+  using distributor_ptr_t = std::unique_ptr<VideoDistributor>;
+
+  std::unordered_map<VideoSource*, distributor_ptr_t> videoSources;
+  time_t time = std::numeric_limits<time_t>::min();
+  bool timeIsValid = false;
+
+  TimeMap<std::nullptr_t> times;
+  bool timesDirty = false;
 };
 
 // ----------------------------------------------------------------------------
@@ -44,62 +58,117 @@ VideoController::~VideoController()
 QSet<VideoSource*> VideoController::videoSources() const
 {
   QTE_D();
-  return d->videoSources;
+
+  auto out = QSet<VideoSource*>{};
+  out.reserve(static_cast<int>(d->videoSources.size()));
+
+  for (auto const& iter : d->videoSources)
+  {
+    out.insert(iter.first);
+  }
+
+  return out;
 }
 
 // ----------------------------------------------------------------------------
-void VideoController::addVideoSource(VideoSource* videoSource)
+VideoDistributor* VideoController::distributor(VideoSource* videoSource) const
+{
+  QTE_D();
+  auto* const item = qtGet(d->videoSources, videoSource);
+  return (item ? item->second.get() : nullptr);
+}
+
+// ----------------------------------------------------------------------------
+VideoDistributor* VideoController::addVideoSource(VideoSource* videoSource)
 {
   QTE_D();
 
-  using Time = kwiver::vital::timestamp::time_t;
-
-  if (!d->videoSources.contains(videoSource))
+  auto& distributor = d->videoSources[videoSource];
+  if (distributor)
   {
-    d->videoSources.insert(videoSource);
-    connect(this, &VideoController::timeSelected,
-            videoSource, &VideoSource::seekTime);
-
-    if (d->videoSources.size() == 1)
-    {
-      auto const& frames = videoSource->frames();
-      if (!frames.empty())
-      {
-        seek(frames.begin().key());
-      }
-    }
-    else
-    {
-      videoSource->seekTime(d->time);
-    }
-
-    emit this->videoSourcesChanged();
+    return distributor.get();
   }
+
+  connect(videoSource, &VideoSource::framesChanged, this,
+          [this, d]{
+            d->timesDirty = true;
+
+            if (!d->timeIsValid)
+            {
+              d->updateTimes();
+              if (!d->times.isEmpty())
+              {
+                this->seek(d->times.begin().key());
+              }
+            }
+
+            emit this->timesChanged();
+          });
+
+  connect(videoSource, &QObject::destroyed, this,
+          [this, videoSource]{
+            this->removeVideoSource(videoSource);
+          });
+
+  auto fetch = [d, videoSource](time_t t, qint64 i){
+    auto* const distributor = d->videoSources[videoSource].get();
+    Q_ASSERT(distributor);
+
+    distributor->requestFrame(videoSource, t, SeekExact, i);
+  };
+
+  distributor = make_unique<VideoDistributor>(this);
+
+  auto const first = (d->videoSources.size() == 1);
+  connect(this, &VideoController::timeSelected,
+          videoSource, fetch);
+
+  d->timesDirty = true;
+  if (!first && d->timeIsValid)
+  {
+    fetch(d->time, -1);
+  }
+
+  videoSource->start();
+
+  emit this->videoSourcesChanged();
+
+  return distributor.get();
 }
 
 // ----------------------------------------------------------------------------
 void VideoController::removeVideoSource(VideoSource* videoSource)
 {
   QTE_D();
-  if (d->videoSources.remove(videoSource))
+
+  auto iter = d->videoSources.find(videoSource);
+  if (iter != d->videoSources.end())
   {
+    auto distributor = std::move(iter->second);
+    d->videoSources.erase(iter);
+
+    disconnect(videoSource, nullptr, this, nullptr);
     disconnect(this, nullptr, videoSource, nullptr);
+
+    d->timesDirty = true;
+
     emit this->videoSourcesChanged();
+    emit this->timesChanged();
+
+    if (d->videoSources.empty())
+    {
+      d->timeIsValid = false;
+    }
   }
 }
 
 // ----------------------------------------------------------------------------
-QSet<kwiver::vital::timestamp::time_t> VideoController::times() const
+TimeMap<std::nullptr_t> VideoController::times()
 {
   QTE_D();
-  QSet<kwiver::vital::timestamp::time_t> result;
 
-  for (auto* vs : d->videoSources)
-  {
-    result.unite(vs->frames().keySet());
-  }
-
-  return result;
+  d->updateTimes();
+  return d->times;
 }
 
 // ----------------------------------------------------------------------------
@@ -110,84 +179,74 @@ kwiver::vital::timestamp::time_t VideoController::time() const
 }
 
 // ----------------------------------------------------------------------------
-void VideoController::seek(kwiver::vital::timestamp::time_t time)
+void VideoController::seek(time_t time, qint64 requestId)
 {
   QTE_D();
-  if (time != d->time)
+
+  if (!d->timeIsValid || time != d->time)
   {
     d->time = time;
-    emit this->timeSelected(time);
+    d->timeIsValid = true;
+    emit this->timeSelected(time, requestId);
   }
 }
 
 // ----------------------------------------------------------------------------
-void VideoController::seekNearest(kwiver::vital::timestamp::time_t time)
+void VideoController::seekNearest(time_t time, qint64 requestId)
 {
   QTE_D();
-  TimeMap<void*> times;
-  for (auto t : this->times())
+
+  d->updateTimes();
+
+  auto it = d->times.find(time, SeekNearest);
+  if (it != d->times.end())
   {
-    times[t] = nullptr;
-  }
-  auto it = times.find(time, SeekNearest);
-  if (it != times.end())
-  {
-    time = it.key();
-  }
-  if (time != d->time)
-  {
-    d->time = time;
-    emit this->timeSelected(time);
+    this->seek(it.key(), requestId);
   }
 }
 
 // ----------------------------------------------------------------------------
-void VideoController::previousFrame()
+void VideoController::previousFrame(qint64 requestId)
 {
   QTE_D();
-  TimeMap<void*> times;
-  for (auto t : this->times())
+
+  d->updateTimes();
+
+  auto const& it = d->times.find(d->time, SeekPrevious);
+  if (it != d->times.end())
   {
-    times[t] = nullptr;
+    this->seek(it.key(), requestId);
   }
-  auto it = times.find(d->time, SeekPrevious);
-  if (it != times.end())
+}
+
+// ----------------------------------------------------------------------------
+void VideoController::nextFrame(qint64 requestId)
+{
+  QTE_D();
+
+  d->updateTimes();
+
+  auto const& it = d->times.find(d->time, SeekNext);
+  if (it != d->times.end())
   {
-    auto time = it.key();
-    if (time != d->time)
+    this->seek(it.key(), requestId);
+  }
+}
+
+// ----------------------------------------------------------------------------
+void VideoControllerPrivate::updateTimes()
+{
+  if (this->timesDirty)
+  {
+    this->times.clear();
+    for (auto const& iter : this->videoSources)
     {
-      d->time = time;
-      emit this->timeSelected(time);
+      this->times.unite(iter.first->frames().keyMap());
     }
+    this->timesDirty = false;
   }
 }
 
-// ----------------------------------------------------------------------------
-void VideoController::nextFrame()
-{
-  QTE_D();
-  TimeMap<void*> times;
-  for (auto t : this->times())
-  {
-    times[t] = nullptr;
-  }
-  auto it = times.find(d->time, SeekNext);
-  if (it != times.end())
-  {
-    auto time = it.key();
-    if (time != d->time)
-    {
-      d->time = time;
-      emit this->timeSelected(time);
-    }
-  }
-}
+} // namespace core
 
-// ----------------------------------------------------------------------------
-void VideoControllerPrivate::rebuildTimes()
-{
-}
-
-}
-
-}
+} // namespace sealtk

--- a/sealtk/core/VideoController.hpp
+++ b/sealtk/core/VideoController.hpp
@@ -6,12 +6,13 @@
 #define sealtk_core_VideoController_hpp
 
 #include <sealtk/core/Export.h>
+#include <sealtk/core/TimeMap.hpp>
 
-#include <QObject>
-#include <QSet>
 #include <qtGlobal.h>
 
-#include <vital/types/timestamp.h>
+#include <QObject>
+
+#include <memory>
 
 namespace sealtk
 {
@@ -19,6 +20,7 @@ namespace sealtk
 namespace core
 {
 
+class VideoDistributor;
 class VideoSource;
 
 class VideoControllerPrivate;
@@ -27,27 +29,32 @@ class SEALTK_CORE_EXPORT VideoController : public QObject
 {
   Q_OBJECT
 
+  using time_t = kwiver::vital::timestamp::time_t;
+
 public:
   explicit VideoController(QObject* parent = nullptr);
   ~VideoController() override;
 
   QSet<VideoSource*> videoSources() const;
-  void addVideoSource(VideoSource* videoSource);
+  VideoDistributor* addVideoSource(VideoSource* videoSource);
   void removeVideoSource(VideoSource* videoSource);
 
-  QSet<kwiver::vital::timestamp::time_t> times() const;
+  VideoDistributor* distributor(VideoSource* videoSource) const;
 
-  kwiver::vital::timestamp::time_t time() const;
+  TimeMap<std::nullptr_t> times();
+
+  time_t time() const;
 
 signals:
   void videoSourcesChanged();
-  void timeSelected(kwiver::vital::timestamp::time_t time);
+  void timesChanged();
+  void timeSelected(time_t time, qint64 requestId);
 
 public slots:
-  void seek(kwiver::vital::timestamp::time_t time);
-  void seekNearest(kwiver::vital::timestamp::time_t time);
-  void previousFrame();
-  void nextFrame();
+  void seek(time_t time, qint64 requestId = -1);
+  void seekNearest(time_t time, qint64 requestId = -1);
+  void previousFrame(qint64 requestId = -1);
+  void nextFrame(qint64 requestId = -1);
 
 protected:
   QTE_DECLARE_PRIVATE(VideoController)

--- a/sealtk/core/VideoDistributor.cpp
+++ b/sealtk/core/VideoDistributor.cpp
@@ -1,0 +1,118 @@
+/* This file is part of SEAL-TK, and is distributed under the OSI-approved BSD
+ * 3-Clause License. See top-level LICENSE file or
+ * https://github.com/Kitware/seal-tk/blob/master/LICENSE for details. */
+
+#include <sealtk/core/VideoDistributor.hpp>
+
+#include <sealtk/core/VideoFrame.hpp>
+#include <sealtk/core/VideoRequest.hpp>
+#include <sealtk/core/VideoRequestor.hpp>
+#include <sealtk/core/VideoSource.hpp>
+
+#include <QPointer>
+
+namespace sealtk
+{
+
+namespace core
+{
+
+// ============================================================================
+class VideoDistributorRequestor : public VideoRequestor
+{
+public:
+  VideoDistributorRequestor(VideoDistributorPrivate* q, QObject* owner)
+    : owner{owner}, q_ptr{q} {}
+
+protected:
+  void update(VideoRequestInfo const& requestInfo,
+              VideoFrame&& response) override;
+
+  QPointer<QObject> const owner;
+
+private:
+  QTE_DECLARE_PUBLIC_PTR(VideoDistributorPrivate);
+  QTE_DECLARE_PUBLIC(VideoDistributorPrivate);
+};
+
+// ============================================================================
+class VideoDistributorPrivate
+{
+public:
+  VideoDistributorPrivate(VideoDistributor* q);
+
+  std::shared_ptr<VideoDistributorRequestor> const requestor;
+
+  void update(qint64 requestId, VideoFrame const& response);
+
+private:
+  QTE_DECLARE_PUBLIC_PTR(VideoDistributor);
+  QTE_DECLARE_PUBLIC(VideoDistributor);
+};
+
+// ----------------------------------------------------------------------------
+QTE_IMPLEMENT_D_FUNC(VideoDistributor)
+
+// ----------------------------------------------------------------------------
+VideoDistributor::VideoDistributor(QObject* parent)
+  : QObject{parent}, d_ptr{new VideoDistributorPrivate{this}}
+{
+}
+
+// ----------------------------------------------------------------------------
+VideoDistributor::~VideoDistributor()
+{
+}
+
+// ----------------------------------------------------------------------------
+void VideoDistributor::requestFrame(
+  VideoSource* videoSource, kwiver::vital::timestamp::time_t time,
+  SeekMode mode, qint64 requestId)
+{
+  QTE_D();
+
+  VideoRequest request;
+  request.requestor = d->requestor;
+  request.requestId = requestId;
+  request.time = time;
+  request.mode = mode;
+
+  videoSource->requestFrame(std::move(request));
+}
+
+// ----------------------------------------------------------------------------
+VideoDistributorPrivate::VideoDistributorPrivate(VideoDistributor* q)
+  : requestor{std::make_shared<VideoDistributorRequestor>(this, q)}, q_ptr{q}
+{
+}
+
+// ----------------------------------------------------------------------------
+void VideoDistributorPrivate::update(
+  qint64 requestId, VideoFrame const& response)
+{
+  QTE_Q();
+
+  if (response.image)
+  {
+    emit q->frameReady(response, requestId);
+  }
+  else
+  {
+    emit q->requestDeclined(requestId);
+  }
+}
+
+// ----------------------------------------------------------------------------
+void VideoDistributorRequestor::update(
+  VideoRequestInfo const& requestInfo, VideoFrame&& response)
+{
+  if (owner)
+  {
+    QTE_Q();
+    q->update(requestInfo.requestId, response);
+  }
+}
+
+} // namespace core
+
+} // namespace sealtk

--- a/sealtk/core/VideoDistributor.hpp
+++ b/sealtk/core/VideoDistributor.hpp
@@ -1,0 +1,65 @@
+/* This file is part of SEAL-TK, and is distributed under the OSI-approved BSD
+ * 3-Clause License. See top-level LICENSE file or
+ * https://github.com/Kitware/seal-tk/blob/master/LICENSE for details. */
+
+#ifndef sealtk_core_VideoDistributor_hpp
+#define sealtk_core_VideoDistributor_hpp
+
+#include <sealtk/core/TimeMap.hpp>
+#include <sealtk/core/VideoFrame.hpp>
+
+#include <qtGlobal.h>
+
+#include <QObject>
+
+namespace sealtk
+{
+
+namespace core
+{
+
+class VideoSource;
+
+class VideoDistributorPrivate;
+
+// ============================================================================
+class SEALTK_CORE_EXPORT VideoDistributor : public QObject
+{
+  Q_OBJECT
+
+public:
+  explicit VideoDistributor(QObject* parent = nullptr);
+
+  ~VideoDistributor() override;
+
+signals:
+  /// Emitted when a frame is obtained in response to a request made by this
+  /// distributor.
+  void frameReady(VideoFrame const& frame, qint64 requestId);
+
+  /// Emitted when a request made by this distributor is declined.
+  void requestDeclined(qint64 requestId);
+
+public slots:
+  /// Request video.
+  ///
+  /// This method is used to request a video frame from the specified
+  /// \p videoSource.
+  ///
+  /// \sa VideoSource::requestFrame, VideoRequest
+  void requestFrame(VideoSource* videoSource,
+                    kwiver::vital::timestamp::time_t time,
+                    SeekMode mode, qint64 requestId = -1);
+
+protected:
+  QTE_DECLARE_PRIVATE(VideoDistributor)
+
+private:
+  QTE_DECLARE_PRIVATE_RPTR(VideoDistributor)
+};
+
+} // namespace core
+
+} // namespace sealtk
+
+#endif

--- a/sealtk/core/VideoFrame.hpp
+++ b/sealtk/core/VideoFrame.hpp
@@ -1,0 +1,29 @@
+/* This file is part of SEAL-TK, and is distributed under the OSI-approved BSD
+ * 3-Clause License. See top-level LICENSE file or
+ * https://github.com/Kitware/seal-tk/blob/master/LICENSE for details. */
+
+#ifndef sealtk_core_VideoFrame_hpp
+#define sealtk_core_VideoFrame_hpp
+
+#include <sealtk/core/VideoMetaData.hpp>
+
+#include <vital/types/image_container.h>
+
+namespace sealtk
+{
+
+namespace core
+{
+
+// ============================================================================
+struct VideoFrame
+{
+  kwiver::vital::image_container_sptr image;
+  VideoMetaData metaData;
+};
+
+} // namespace core
+
+} // namespace sealtk
+
+#endif

--- a/sealtk/core/VideoProvider.hpp
+++ b/sealtk/core/VideoProvider.hpp
@@ -1,0 +1,64 @@
+/* This file is part of SEAL-TK, and is distributed under the OSI-approved BSD
+ * 3-Clause License. See top-level LICENSE file or
+ * https://github.com/Kitware/seal-tk/blob/master/LICENSE for details. */
+
+#ifndef sealtk_core_VideoProvider_hpp
+#define sealtk_core_VideoProvider_hpp
+
+#include <sealtk/core/Export.h>
+
+#include <QObject>
+
+namespace sealtk
+{
+
+namespace core
+{
+
+struct VideoRequest;
+
+class VideoSourcePrivate;
+
+// ============================================================================
+/// Abstract video provider.
+///
+/// This class provides an interface for the threaded implementation of
+/// #VideoSource implementations. Its use allows the base #VideoSource
+/// implementation to interface with the concrete implementation in order to
+/// manage request queuing and other common tasks related to the multi-threaded
+/// nature of video sources.
+class SEALTK_CORE_EXPORT VideoProvider : public QObject
+{
+protected:
+  friend class VideoSourcePrivate;
+
+  VideoProvider(QObject* parent = nullptr) : QObject{parent} {}
+  virtual ~VideoProvider() = default;
+
+  /// Initialize the video source.
+  ///
+  /// This method is called in the video source thread to prepare the video
+  /// source for use. It executed from the video source's private thread.
+  /// Implementations should strive to delay any long-running code until this
+  /// method is called, in order to avoid blocking the UI.
+  virtual void initialize() = 0;
+
+  /// Process a video request.
+  ///
+  /// This method must be overridden by implementations. The #VideoSource
+  /// implementation should handle the request by finding and replying with
+  /// the requested frame and returning the timestamp of the same, or returning
+  /// an invalid timestam if a) the request cannot be satisfied, or b) the
+  /// request resolves to the same frame as \p lastTime.
+  ///
+  /// If an invalid timestamp is returned, the base VideoSource will take care
+  /// of issuing an empty response if required.
+  virtual kwiver::vital::timestamp processRequest(
+    VideoRequest&& request, kwiver::vital::timestamp const& lastTime) = 0;
+};
+
+} // namespace core
+
+} // namespace sealtk
+
+#endif

--- a/sealtk/core/VideoRequest.cpp
+++ b/sealtk/core/VideoRequest.cpp
@@ -1,0 +1,30 @@
+/* This file is part of SEAL-TK, and is distributed under the OSI-approved BSD
+ * 3-Clause License. See top-level LICENSE file or
+ * https://github.com/Kitware/seal-tk/blob/master/LICENSE for details. */
+
+#include <sealtk/core/VideoRequest.hpp>
+
+#include <sealtk/core/VideoFrame.hpp>
+#include <sealtk/core/VideoRequestor.hpp>
+
+namespace sealtk
+{
+
+namespace core
+{
+
+// ----------------------------------------------------------------------------
+void VideoRequest::sendReply(VideoFrame&& frame) const
+{
+  auto* const requestor = this->requestor.get();
+  auto const info = VideoRequestInfo{*this};
+
+  QMetaObject::invokeMethod(
+    requestor, [requestor, info, frame = std::move(frame)]() mutable {
+      requestor->update(info, std::move(frame));
+    });
+}
+
+} // namespace core
+
+} // namespace sealtk

--- a/sealtk/core/VideoRequest.hpp
+++ b/sealtk/core/VideoRequest.hpp
@@ -1,0 +1,89 @@
+/* This file is part of SEAL-TK, and is distributed under the OSI-approved BSD
+ * 3-Clause License. See top-level LICENSE file or
+ * https://github.com/Kitware/seal-tk/blob/master/LICENSE for details. */
+
+#ifndef sealtk_core_VideoRequest_hpp
+#define sealtk_core_VideoRequest_hpp
+
+#include <sealtk/core/Export.h>
+#include <sealtk/core/TimeMap.hpp>
+
+#include <qtTransferablePointer.h>
+
+#include <memory>
+
+namespace sealtk
+{
+
+namespace core
+{
+
+class VideoRequestor;
+class VideoFrame;
+
+// ============================================================================
+/// Common information for a video request.
+///
+/// This structure provides a subset of the information that comprises a
+/// complete video request. This subset consists of data which is trivial to
+/// copy (in particular, it excludes the shared pointer to the requestor), and
+/// is used when sending a response to a request.
+struct SEALTK_CORE_EXPORT VideoRequestInfo
+{
+  /// Unique identifier of this request.
+  ///
+  /// This field provides a unique (to the requestor) identifier for the
+  /// request which requestors can use to correlate requests to replies. This
+  /// is useful in some situations since sources normally reply only to the
+  /// most recent request. A negative value is "invalid"; if the identifier is
+  /// negative, the source will reuse the most recent non-negative identifier
+  /// when replying. Additionally, if a request cannot be satisfied, the source
+  /// will only issue a response if the outstanding request identifier is
+  /// non-negative.
+  qint64 requestId = -1;
+
+  /// Desired time of video to retrieve.
+  ///
+  /// This field specifies the desired time of the video frame to being
+  /// requested. The actual time that will be retrieved also depends on the
+  /// seek mode.
+  kwiver::vital::timestamp::time_t time;
+
+  /// Temporal seek mode.
+  ///
+  /// This field specifies how the requested time point should be interpreted.
+  SeekMode mode = SeekNearest;
+};
+
+// ============================================================================
+/// Video request.
+///
+/// This structure fully describes a video request. Most of the information is
+/// carried by the base #VideoRequestInfo structure.
+struct SEALTK_CORE_EXPORT VideoRequest : VideoRequestInfo
+{
+  /// Send reply to the request.
+  ///
+  /// This method invokes VideoRequestor::update on the requestor with the
+  /// supplied \p response and a copy of the request information. If the
+  /// requestor's event loop is running in a thread other than the thread which
+  /// calls this method, the response will be delivered asynchronously.
+  ///
+  /// \sa requestId
+  void sendReply(VideoFrame&& response) const;
+
+  /// Pointer to requestor.
+  ///
+  /// This field provides a shared reference to the requestor that issued this
+  /// request. The use of a shared pointer ensures that the video source is
+  /// able to safely issue a response without being subject to race conditions
+  /// if the video source and the final consumer of the video live in separate
+  /// threads.
+  std::shared_ptr<VideoRequestor> requestor;
+};
+
+} // namespace core
+
+} // namespace sealtk
+
+#endif

--- a/sealtk/core/VideoRequestor.cpp
+++ b/sealtk/core/VideoRequestor.cpp
@@ -1,0 +1,20 @@
+/* This file is part of SEAL-TK, and is distributed under the OSI-approved BSD
+ * 3-Clause License. See top-level LICENSE file or
+ * https://github.com/Kitware/seal-tk/blob/master/LICENSE for details. */
+
+#include <sealtk/core/VideoRequestor.hpp>
+
+namespace sealtk
+{
+
+namespace core
+{
+
+// ----------------------------------------------------------------------------
+VideoRequestor::VideoRequestor(QObject* parent) : QObject{parent}
+{
+}
+
+} // namespace core
+
+} // namespace sealtk

--- a/sealtk/core/VideoRequestor.hpp
+++ b/sealtk/core/VideoRequestor.hpp
@@ -1,0 +1,43 @@
+/* This file is part of SEAL-TK, and is distributed under the OSI-approved BSD
+ * 3-Clause License. See top-level LICENSE file or
+ * https://github.com/Kitware/seal-tk/blob/master/LICENSE for details. */
+
+#ifndef sealtk_core_VideoRequestor_hpp
+#define sealtk_core_VideoRequestor_hpp
+
+#include <sealtk/core/Export.h>
+
+#include <QObject>
+
+namespace sealtk
+{
+
+namespace core
+{
+
+class VideoFrame;
+class VideoRequest;
+class VideoRequestInfo;
+
+// ============================================================================
+class SEALTK_CORE_EXPORT VideoRequestor : public QObject
+{
+  Q_OBJECT
+
+public:
+  virtual ~VideoRequestor() = default;
+
+protected:
+  friend class VideoRequest;
+
+  explicit VideoRequestor(QObject* parent = nullptr);
+
+  virtual void update(VideoRequestInfo const& requestInfo,
+                      VideoFrame&& response) = 0;
+};
+
+} // namespace core
+
+} // namespace sealtk
+
+#endif

--- a/sealtk/core/VideoSource.cpp
+++ b/sealtk/core/VideoSource.cpp
@@ -4,6 +4,19 @@
 
 #include <sealtk/core/VideoSource.hpp>
 
+#include <sealtk/core/VideoFrame.hpp>
+#include <sealtk/core/VideoProvider.hpp>
+#include <sealtk/core/VideoRequest.hpp>
+#include <sealtk/core/VideoRequestor.hpp>
+
+#include <QDebug>
+#include <QPointer>
+#include <QThread>
+
+#include <unordered_map>
+
+namespace kv = kwiver::vital;
+
 namespace sealtk
 {
 
@@ -11,26 +24,194 @@ namespace core
 {
 
 // ============================================================================
-class VideoSourcePrivate
+class VideoSourceThread : public QThread
 {
 public:
+  VideoSourceThread(VideoSourcePrivate* q) : q_ptr{q} {}
+
+protected:
+  QTE_DECLARE_PUBLIC_PTR(VideoSourcePrivate);
+
+  void run() override;
+
+private:
+  QTE_DECLARE_PUBLIC(VideoSourcePrivate);
+};
+
+// ============================================================================
+class VideoSourcePrivate : public QObject
+{
+public:
+  VideoSourcePrivate(VideoProvider* provider);
+
+  void initializeProvider();
+  void enqueueFrameRequest(VideoRequest&& request);
+  void dispatchFrameRequests();
+
+  std::unordered_map<VideoRequestor*, VideoRequest> requests;
+  std::unordered_map<VideoRequestor*, kv::timestamp> lastFrameProvided;
+
+  VideoSourceThread thread;
+  QPointer<VideoProvider> const provider;
 };
 
 // ----------------------------------------------------------------------------
 QTE_IMPLEMENT_D_FUNC(VideoSource)
 
 // ----------------------------------------------------------------------------
-VideoSource::VideoSource(QObject* parent)
-  : QObject{parent},
-    d_ptr{new VideoSourcePrivate}
+VideoSource::VideoSource(VideoProvider* provider, QObject* parent)
+  : QObject{parent}, d_ptr{new VideoSourcePrivate{provider}}
 {
 }
 
 // ----------------------------------------------------------------------------
 VideoSource::~VideoSource()
 {
+  this->cleanup();
 }
 
+// ----------------------------------------------------------------------------
+void VideoSource::start()
+{
+  QTE_D();
+
+  d->moveToThread(&d->thread);
+  d->provider->moveToThread(&d->thread);
+  d->thread.start();
 }
 
+// ----------------------------------------------------------------------------
+void VideoSource::cleanup()
+{
+  QTE_D();
+
+  if (d->thread.isRunning())
+  {
+    if (!d->provider)
+    {
+      qCritical()
+        << this
+        << "provider is destroyed but source's thread is still running";
+      qDebug()
+        << "(a derived type probably forgot to call cleanup())";
+      qFatal("terminating execution as program is likely about to crash");
+    }
+
+    d->thread.exit();
+    d->thread.wait();
+  }
 }
+
+// ----------------------------------------------------------------------------
+void VideoSource::requestFrame(VideoRequest&& request)
+{
+  QTE_D();
+
+  if (!d->thread.isRunning())
+  {
+    this->start();
+  }
+
+  QMetaObject::invokeMethod(
+    d, [d, request = std::move(request)]() mutable {
+      d->enqueueFrameRequest(std::move(request));
+    });
+}
+
+// ----------------------------------------------------------------------------
+void VideoSource::requestFrame(VideoRequest const& request)
+{
+  auto requestCopy = request;
+  return this->requestFrame(std::move(requestCopy));
+}
+
+// ----------------------------------------------------------------------------
+void VideoSourceThread::run()
+{
+  QTE_Q();
+
+  q->initializeProvider();
+  this->exec();
+}
+
+// ----------------------------------------------------------------------------
+VideoSourcePrivate::VideoSourcePrivate(VideoProvider* provider)
+  : thread{this}, provider{provider}
+{
+}
+
+// ----------------------------------------------------------------------------
+void VideoSourcePrivate::initializeProvider()
+{
+  this->provider->initialize();
+}
+
+// ----------------------------------------------------------------------------
+void VideoSourcePrivate::enqueueFrameRequest(VideoRequest&& request)
+{
+  // If this will be the first frame request of a batch (i.e. all previous
+  // requests have been dispatched)...
+  if (this->requests.empty())
+  {
+    // ...then schedule an event to dispatch this request (and any others that
+    // are received between now and the next round of dispatching)
+    QMetaObject::invokeMethod(
+      this, &VideoSourcePrivate::dispatchFrameRequests,
+      Qt::QueuedConnection);
+  }
+
+  // Enqueue request, potentially replacing existing request, and potentially
+  // inheriting the request ID from the existing request
+  auto* const requestor = request.requestor.get();
+  auto& priorRequest = this->requests[requestor];
+  if (request.requestId < 0)
+  {
+    request.requestId = priorRequest.requestId;
+  }
+  priorRequest = std::move(request);
+
+  // Check if we have seen this request before
+  if (!this->lastFrameProvided.count(requestor)) // TODO(C++20): use contains
+  {
+    // Set up a callback to erase our records of a requestor when it goes
+    // away... note that this doesn't need to clean up the request queue, since
+    // the request includes a smart pointer to the requestor, which means the
+    // requestor cannot possibly go away while it has outstanding requests
+    this->lastFrameProvided.insert({requestor, {}});
+    connect(requestor, &QObject::destroyed, this,
+            [this, requestor]{
+              this->lastFrameProvided.erase(requestor);
+            });
+  }
+}
+
+// ----------------------------------------------------------------------------
+void VideoSourcePrivate::dispatchFrameRequests()
+{
+  for (auto& request : this->requests)
+  {
+    Q_ASSERT(request.first == request.second.requestor.get());
+    Q_ASSERT(this->lastFrameProvided.count(request.first)); // TODO(C++20)
+
+    auto const& last = this->lastFrameProvided[request.first];
+    auto const response =
+      this->provider->processRequest(std::move(request.second), last);
+
+    // Record the last time provided to the requestor, or send an empty frame
+    // if a response is required
+    if (response.is_valid())
+    {
+      this->lastFrameProvided[request.first] = response;
+    }
+    else if (request.second.requestId >= 0)
+    {
+      auto dummyFrame = VideoFrame{nullptr, VideoMetaData{}};
+      request.second.sendReply(std::move(dummyFrame));
+    }
+  }
+  this->requests.clear();
+}
+
+} // namespace core
+
+} // namespace sealtk

--- a/sealtk/core/VideoSource.hpp
+++ b/sealtk/core/VideoSource.hpp
@@ -7,14 +7,9 @@
 
 #include <sealtk/core/Export.h>
 #include <sealtk/core/TimeMap.hpp>
-#include <sealtk/core/VideoMetaData.hpp>
-
-#include <vital/types/detected_object_set.h>
-#include <vital/types/image_container.h>
 
 #include <qtGlobal.h>
 
-#include <QImage>
 #include <QObject>
 
 namespace sealtk
@@ -23,44 +18,113 @@ namespace sealtk
 namespace core
 {
 
+class VideoProvider;
+
+struct VideoRequest;
+
 class VideoSourcePrivate;
 
+// ============================================================================
 class SEALTK_CORE_EXPORT VideoSource : public QObject
 {
   Q_OBJECT
 
 public:
-  explicit VideoSource(QObject* parent = nullptr);
   ~VideoSource() override;
 
+  /// Query if the video source is "ready".
+  ///
+  /// This method is used to determine if the video source is "ready". In
+  /// particular, this method can be used to determine if #frames will return
+  /// meaningful data. A source will not return \c true until #start has been
+  /// called, and until the initial frame set has been passed from the source's
+  /// internal thread to the thread which owns the #VideoSource object.
+  virtual bool isReady() const = 0;
+
+  /// Get the set of frames for which this source has video.
+  ///
+  /// This method returns a map of times for which the video source has video,
+  /// mapped to their corresponding frames. Note that calling this method
+  /// before #framesChanged() is emitted may return an empty map.
   virtual TimeMap<kwiver::vital::timestamp::frame_t> frames() const = 0;
 
 signals:
-  void imageReady(
-    kwiver::vital::image_container_sptr const& image,
-    VideoMetaData const& metaData) const;
-  void detectionsReady(
-    kwiver::vital::detected_object_set_sptr const& detetedObjectSet,
-    kwiver::vital::timestamp const& timeStamp) const;
-  void videoInputChanged() const;
+  /// Emitted when the set of available frames changes.
+  ///
+  /// This signal is emitted when the set of available frames changes. While
+  /// this has obvious use for "streaming" sources (that is, the set of frames
+  /// is properly time variable), even "static" sources, because video is
+  /// normally loaded asynchronously, should emit this signal at least once to
+  /// indicate when they are ready for users to call #frames.
+  void framesChanged();
 
 public slots:
-  virtual void invalidate() const = 0;
-  virtual void seek(kwiver::vital::timestamp::time_t time, SeekMode mode) = 0;
-  virtual void seekFrame(kwiver::vital::timestamp::frame_t frame) = 0;
+  /// "Start" the video source.
+  ///
+  /// This method finalizes the construction of a video source. It must be
+  /// called prior to using the video source, preferably by whatever code
+  /// constructed the video source. If necessary, it will be called by
+  /// #requestFrame, however this may impose a non-trivial latency on initial
+  /// requests if the source must perform work in the source thread to prepare
+  /// the source for use.
+  ///
+  /// The video source will not emit signals until this method has been called.
+  /// If necessary, this gives users a chance to connect to #framesChanged
+  ///
+  /// \note
+  ///   It is safe to call this method more than once, as long as it is not
+  ///   called during destruction of the #VideoSource. Once this method is
+  ///   called, the underlying #VideoProvider is moved to the video source's
+  ///   service thread.
+  void start();
 
-  virtual void seekTime(kwiver::vital::timestamp::time_t time)
-  { seek(time, SeekExact); }
+  //@{
+  /// Request video.
+  ///
+  /// This method is used to request a video frame from the source. If the
+  /// requestor has previously requested a frame, and the request would
+  /// otherwise result in the same frame being provided, then no frame is
+  /// returned, and a response will only be sent if the requestor is waiting
+  /// on a request with a non-negative request identifier.
+  ///
+  /// Note that it is slightly more efficient to provide the request as an
+  /// r-value reference, as this will usually reduce the number of reference
+  /// counting operations required to service the request.
+  ///
+  /// \sa ready
+  void requestFrame(VideoRequest&& request);
+  void requestFrame(VideoRequest const& request);
+  //@}
 
 protected:
+  explicit VideoSource(VideoProvider* provider, QObject* parent = nullptr);
+
+  /// Clean up the video source.
+  ///
+  /// This method cleans up the video source, in particular, by signaling the
+  /// internal thread to terminate and waiting for it to do so. This method
+  /// should be called from the destructor of classes inheriting #VideoSource.
+  /// This is especially critical if the #VideoProvider is owned by the derived
+  /// class (which is usually the case, and indeed, is recommended), as
+  /// otherwise the provider may be destroyed while its thread is still
+  /// executing.
+  ///
+  /// \note
+  ///   It is safe to call this method more than once. Because failing to call
+  ///   this method is very likely to cause the program to crash or otherwise
+  ///   fall into the Dread Realm of Undefined Behavior, the base class
+  ///   attempts to detect such failure and will issue a fatal program error in
+  ///   such cases.
+  void cleanup();
+
   QTE_DECLARE_PRIVATE(VideoSource)
 
 private:
   QTE_DECLARE_PRIVATE_RPTR(VideoSource)
 };
 
-}
+} // namespace core
 
-}
+} // namespace sealtk
 
 #endif

--- a/sealtk/core/VideoSourceFactory.cpp
+++ b/sealtk/core/VideoSourceFactory.cpp
@@ -4,8 +4,6 @@
 
 #include <sealtk/core/VideoSourceFactory.hpp>
 
-#include <sealtk/core/VideoController.hpp>
-
 namespace sealtk
 {
 
@@ -16,37 +14,19 @@ namespace core
 class VideoSourceFactoryPrivate
 {
 public:
-  VideoSourceFactoryPrivate(VideoController* videoController);
-
-  VideoController* videoController;
 };
 
 // ----------------------------------------------------------------------------
 QTE_IMPLEMENT_D_FUNC(VideoSourceFactory)
 
 // ----------------------------------------------------------------------------
-VideoSourceFactory::VideoSourceFactory(VideoController* parent)
-  : QObject{parent},
-    d_ptr{new VideoSourceFactoryPrivate{parent}}
+VideoSourceFactory::VideoSourceFactory(QObject* parent)
+  : QObject{parent}, d_ptr{new VideoSourceFactoryPrivate}
 {
 }
 
 // ----------------------------------------------------------------------------
 VideoSourceFactory::~VideoSourceFactory()
-{
-}
-
-// ----------------------------------------------------------------------------
-VideoController* VideoSourceFactory::videoController() const
-{
-  QTE_D();
-  return d->videoController;
-}
-
-// ----------------------------------------------------------------------------
-VideoSourceFactoryPrivate::VideoSourceFactoryPrivate(
-  VideoController* videoController)
-  : videoController{videoController}
 {
 }
 

--- a/sealtk/core/VideoSourceFactory.hpp
+++ b/sealtk/core/VideoSourceFactory.hpp
@@ -16,7 +16,6 @@ namespace sealtk
 namespace core
 {
 
-class VideoController;
 class VideoSource;
 
 class VideoSourceFactoryPrivate;
@@ -26,10 +25,8 @@ class SEALTK_CORE_EXPORT VideoSourceFactory : public QObject
   Q_OBJECT
 
 public:
-  explicit VideoSourceFactory(VideoController* parent = nullptr);
+  explicit VideoSourceFactory(QObject* parent = nullptr);
   ~VideoSourceFactory() override;
-
-  VideoController* videoController() const;
 
 signals:
   void videoSourceLoaded(void* handle, VideoSource* videoSource);

--- a/sealtk/core/test/CMakeLists.txt
+++ b/sealtk/core/test/CMakeLists.txt
@@ -10,10 +10,12 @@ sealtk_add_library(sealtk::core_test_common
 
   SOURCES
     TestCommon.cpp
+    TestVideo.cpp
 
   PRIVATE_LINK_LIBRARIES
     qtExtensionsHeaders
     Qt5::Core
+    sealtk::core
     kwiver::vital
     kwiver::vital_algo
   )

--- a/sealtk/core/test/TestVideo.cpp
+++ b/sealtk/core/test/TestVideo.cpp
@@ -1,0 +1,50 @@
+/* This file is part of SEAL-TK, and is distributed under the OSI-approved BSD
+ * 3-Clause License. See top-level LICENSE file or
+ * https://github.com/Kitware/seal-tk/blob/master/LICENSE for details. */
+
+#include <sealtk/core/test/TestVideo.hpp>
+
+namespace kv = kwiver::vital;
+
+namespace sealtk
+{
+
+namespace core
+{
+
+namespace test
+{
+
+// ----------------------------------------------------------------------------
+void TestVideoRequestor::request(
+  VideoSource* source, kv::timestamp::time_t time)
+{
+  // Build request
+  VideoRequest request;
+  request.requestId = 0; // Require a response
+  request.requestor = this->shared_from_this();
+  request.mode = SeekExact;
+  request.time = time;
+
+  // Issue request
+  source->requestFrame(std::move(request));
+
+  // Wait for response
+  this->eventLoop.exec();
+}
+
+// ----------------------------------------------------------------------------
+void TestVideoRequestor::update(
+  VideoRequestInfo const& requestInfo, VideoFrame&& response)
+{
+  Q_UNUSED(requestInfo);
+
+  this->receivedFrames.append(std::move(response));
+  this->eventLoop.quit();
+}
+
+} // namespace test
+
+} // namespace core
+
+} // namespace sealtk

--- a/sealtk/core/test/TestVideo.hpp
+++ b/sealtk/core/test/TestVideo.hpp
@@ -1,0 +1,54 @@
+/* This file is part of SEAL-TK, and is distributed under the OSI-approved BSD
+ * 3-Clause License. See top-level LICENSE file or
+ * https://github.com/Kitware/seal-tk/blob/master/LICENSE for details. */
+
+#ifndef sealtk_core_test_TestVideo_hpp
+#define sealtk_core_test_TestVideo_hpp
+
+#include <sealtk/core/VideoFrame.hpp>
+#include <sealtk/core/VideoRequest.hpp>
+#include <sealtk/core/VideoRequestor.hpp>
+#include <sealtk/core/VideoSource.hpp>
+
+#include <vital/types/timestamp.h>
+
+#include <QEventLoop>
+#include <QVector>
+
+#include <memory>
+
+namespace sealtk
+{
+
+namespace core
+{
+
+namespace test
+{
+
+// ============================================================================
+class TestVideoRequestor
+  : public VideoRequestor,
+    public std::enable_shared_from_this<TestVideoRequestor>
+{
+  Q_OBJECT
+
+public:
+  void request(VideoSource* source, kwiver::vital::timestamp::time_t time);
+
+  QVector<VideoFrame> receivedFrames;
+
+protected:
+  QEventLoop eventLoop;
+
+  void update(VideoRequestInfo const& requestInfo,
+              VideoFrame&& response) override;
+};
+
+} // namespace test
+
+} // namespace core
+
+} // namespace sealtk
+
+#endif

--- a/sealtk/core/test/VideoController.cpp
+++ b/sealtk/core/test/VideoController.cpp
@@ -9,25 +9,27 @@
 #include <sealtk/core/ImageUtils.hpp>
 #include <sealtk/core/KwiverVideoSource.hpp>
 #include <sealtk/core/VideoController.hpp>
+#include <sealtk/core/VideoDistributor.hpp>
+#include <sealtk/core/VideoFrame.hpp>
 
 #include <sealtk/util/unique.hpp>
 
 #include <vital/algo/video_input.h>
 #include <vital/config/config_block.h>
-#include <vital/types/timestamp.h>
 
-#include <arrows/qt/image_container.h>
+#include <vital/range/indirect.h>
+#include <vital/range/iota.h>
 
 #include <qtStlUtil.h>
 
 #include <QImage>
-#include <QVector>
 
 #include <QtTest>
 
 #include <array>
 
 namespace kv = kwiver::vital;
+namespace kvr = kwiver::vital::range;
 
 namespace sealtk
 {
@@ -37,6 +39,29 @@ namespace core
 
 namespace test
 {
+
+// ============================================================================
+struct TestVideoSink
+{
+  void waitForFrame(QEventLoop& eventLoop);
+
+  QVector<VideoFrame> receivedFrames;
+  bool frameReceived = false;
+};
+
+// ----------------------------------------------------------------------------
+void TestVideoSink::waitForFrame(QEventLoop& eventLoop)
+{
+  // If we haven't already received a frame since the last call...
+  while (!this->frameReceived)
+  {
+    // ...then wait for a response now
+    eventLoop.exec();
+  }
+
+  // Reset flag
+  this->frameReceived = false;
+}
 
 // ============================================================================
 class TestVideoController : public QObject
@@ -54,20 +79,94 @@ private slots:
 private:
   kv::config_block_sptr config;
   std::unique_ptr<VideoController> videoController;
-  QVector<KwiverVideoSource*> videoSources;
+  QHash<VideoSource*, TestVideoSink> videoSinks;
+  std::vector<VideoSource*> videoSources;
+  QEventLoop eventLoop;
 
-  kv::algo::video_input_sptr generateVideoInput(QString const& path);
+  void createVideoSource(QString const& path);
+  void waitForFrames(VideoSource* excludedSource = nullptr);
+  void compareFrames(std::array<QVector<QString>, 3> const& seekFiles) const;
 };
 
 // ----------------------------------------------------------------------------
-kv::algo::video_input_sptr TestVideoController::generateVideoInput(
-  QString const& path)
+void TestVideoController::createVideoSource(QString const& path)
 {
   kv::algo::video_input_sptr vi;
   kv::algo::video_input::set_nested_algo_configuration(
     "video_reader", this->config, vi);
+
+  QVERIFY(vi);
+
   vi->open(stdString(path));
-  return vi;
+  auto* const vs = new KwiverVideoSource{vi, this->videoController.get()};
+  auto* const vd = this->videoController->addVideoSource(vs);
+
+  auto& sink = this->videoSinks[vs];
+  connect(vd, &VideoDistributor::requestDeclined, this,
+          [&sink, this]{
+            sink.receivedFrames.append({nullptr, VideoMetaData{}});
+            sink.frameReceived = true;
+            this->eventLoop.quit();
+          });
+  connect(vd, &VideoDistributor::frameReady, this,
+          [&sink, this](VideoFrame const& frame){
+            sink.receivedFrames.append(frame);
+            sink.frameReceived = true;
+            this->eventLoop.quit();
+          });
+
+  this->videoSources.push_back(vs);
+  vs->start();
+}
+
+// ----------------------------------------------------------------------------
+void TestVideoController::waitForFrames(VideoSource* excludedSource)
+{
+  for (auto iter : this->videoSinks | kvr::indirect)
+  {
+    if (iter.key() != excludedSource) // for removeVideoSource test
+    {
+      iter->waitForFrame(this->eventLoop);
+    }
+  }
+}
+
+// ----------------------------------------------------------------------------
+void TestVideoController::compareFrames(
+  std::array<QVector<QString>, 3> const& seekFiles) const
+{
+  QCOMPARE(this->videoSources.size(), seekFiles.size());
+
+  for (auto const i : kvr::iota(this->videoSources.size()))
+  {
+    auto* const source = this->videoSources[i];
+    auto const& sink = this->videoSinks[source];
+    auto const& seekFrames = sink.receivedFrames;
+    QCOMPARE(seekFrames.size(), seekFiles[i].size());
+
+    for (auto const j : kvr::iota(seekFiles[i].size()))
+    {
+      auto const& frame = seekFrames[j];
+
+      if (!seekFiles[i][j].isEmpty())
+      {
+        auto const& expected = QImage{sealtk::test::testDataPath(
+          "VideoController/" + seekFiles[i][j])};
+        auto const& actual =
+          sealtk::core::imageContainerToQImage(frame.image);
+        QCOMPARE(actual, expected);
+
+        QFileInfo fiActual{qtString(frame.metaData.imageName())};
+        QFileInfo fiExpected{seekFiles[i][j]};
+        QCOMPARE(fiActual.fileName(), fiExpected.fileName());
+      }
+      else
+      {
+        QCOMPARE(frame.image.get(), nullptr);
+        QVERIFY(frame.metaData.imageName().empty());
+      }
+    }
+  }
 }
 
 // ----------------------------------------------------------------------------
@@ -87,30 +186,18 @@ void TestVideoController::init()
 {
   this->videoController = make_unique<VideoController>();
 
-  KwiverVideoSource* vs;
-
-  vs = new KwiverVideoSource{this->videoController.get()};
-  vs->setVideoInput(this->generateVideoInput(SEALTK_TEST_DATA_PATH(
-    "VideoController/1/list.txt")));
-  this->videoController->addVideoSource(vs);
-  this->videoSources.append(vs);
-
-  vs = new KwiverVideoSource{this->videoController.get()};
-  vs->setVideoInput(this->generateVideoInput(SEALTK_TEST_DATA_PATH(
-    "VideoController/2/list.txt")));
-  this->videoController->addVideoSource(vs);
-  this->videoSources.append(vs);
-
-  vs = new KwiverVideoSource{this->videoController.get()};
-  vs->setVideoInput(this->generateVideoInput(SEALTK_TEST_DATA_PATH(
-    "VideoController/3/list.txt")));
-  this->videoController->addVideoSource(vs);
-  this->videoSources.append(vs);
+  this->createVideoSource(
+    SEALTK_TEST_DATA_PATH("VideoController/1/list.txt"));
+  this->createVideoSource(
+    SEALTK_TEST_DATA_PATH("VideoController/2/list.txt"));
+  this->createVideoSource(
+    SEALTK_TEST_DATA_PATH("VideoController/3/list.txt"));
 }
 
 // ----------------------------------------------------------------------------
 void TestVideoController::cleanup()
 {
+  this->videoSinks.clear();
   this->videoSources.clear();
   this->videoController.reset();
 }
@@ -137,47 +224,13 @@ void TestVideoController::seek()
     },
   }};
 
-  std::array<QVector<QImage>, 3> seekImages;
-
-  for (int i = 0; i < 3; i++)
-  {
-    connect(this->videoSources[i], &VideoSource::imageReady,
-            [&seekImages, i](kv::image_container_sptr const& image)
-    {
-      if (image)
-      {
-        seekImages[i].append(sealtk::core::imageContainerToQImage(image));
-      }
-      else
-      {
-        seekImages[i].append(QImage{});
-      }
-    });
-  }
-
   for (auto t : seekTimes)
   {
-    this->videoController->seek(t);
+    this->videoController->seek(t, 0);
+    this->waitForFrames();
   }
 
-  for (int i = 0; i < 3; i++)
-  {
-    QCOMPARE(seekImages[i].size(), seekFiles[i].size());
-
-    for (int j = 0; j < seekFiles[i].size(); j++)
-    {
-      if (!seekFiles[i][j].isNull())
-      {
-        QImage expected{sealtk::test::testDataPath(
-          "VideoController/" + seekFiles[i][j])};
-        QCOMPARE(seekImages[i][j], expected);
-      }
-      else
-      {
-        QCOMPARE(seekImages[i][j], QImage{});
-      }
-    }
-  }
+  this->compareFrames(seekFiles);
 }
 
 // ----------------------------------------------------------------------------
@@ -201,54 +254,22 @@ void TestVideoController::removeVideoSource()
     },
   }};
 
-  std::array<QVector<QImage>, 3> seekImages;
-
-  for (int i = 0; i < 3; i++)
-  {
-    connect(this->videoSources[i], &VideoSource::imageReady,
-            [&seekImages, i](kv::image_container_sptr const& image)
-    {
-      if (image)
-      {
-        seekImages[i].append(sealtk::core::imageContainerToQImage(image));
-      }
-      else
-      {
-        seekImages[i].append(QImage{});
-      }
-    });
-  }
-
   for (int i = 0; i < 4; i++)
   {
-    this->videoController->seek(seekTimes[i]);
+    this->videoController->seek(seekTimes[i], 0);
+    this->waitForFrames();
   }
 
-  this->videoController->removeVideoSource(this->videoSources[2]);
+  auto* const testSource = this->videoSources[2];
+  this->videoController->removeVideoSource(testSource);
 
   for (int i = 4; i < seekTimes.size(); i++)
   {
-    this->videoController->seek(seekTimes[i]);
+    this->videoController->seek(seekTimes[i], 0);
+    this->waitForFrames(testSource);
   }
 
-  for (int i = 0; i < 3; i++)
-  {
-    QCOMPARE(seekImages[i].size(), seekFiles[i].size());
-
-    for (int j = 0; j < seekFiles[i].size(); j++)
-    {
-      if (!seekFiles[i][j].isNull())
-      {
-        QImage expected{sealtk::test::testDataPath(
-          "VideoController/" + seekFiles[i][j])};
-        QCOMPARE(seekImages[i][j], expected);
-      }
-      else
-      {
-        QCOMPARE(seekImages[i][j], QImage{});
-      }
-    }
-  }
+  this->compareFrames(seekFiles);
 }
 
 // ----------------------------------------------------------------------------
@@ -258,14 +279,24 @@ void TestVideoController::times()
     100, 200, 300, 400, 500, 600,
   };
 
-  QCOMPARE(this->videoController->times(), times);
+  // Busy-loop until all sources report readiness; this is hardly the most
+  // efficient way, but it is the safest
+  for (auto& source : this->videoSources)
+  {
+    while (!source->isReady())
+    {
+      QApplication::processEvents();
+    }
+  }
+
+  QCOMPARE(this->videoController->times().keySet(), times);
 }
 
-}
+} // namespace test
 
-}
+} // namespace core
 
-}
+} // namespace sealtk
 
 // ----------------------------------------------------------------------------
 QTEST_MAIN(sealtk::core::test::TestVideoController)

--- a/sealtk/gui/Player.hpp
+++ b/sealtk/gui/Player.hpp
@@ -7,7 +7,7 @@
 
 #include <sealtk/gui/Export.h>
 
-#include <sealtk/core/VideoSource.hpp>
+#include <sealtk/core/VideoDistributor.hpp>
 
 #include <QMatrix3x3>
 #include <QOpenGLWidget>
@@ -51,13 +51,12 @@ public:
 
   float zoom() const;
   QPointF center() const;
-  core::VideoSource* videoSource() const;
+  core::VideoDistributor* videoSource() const;
   ContrastMode contrastMode() const;
 
 signals:
   void zoomChanged(float zoom) const;
   void centerChanged(QPointF center) const;
-  void videoSourceChanged(core::VideoSource* videoSource) const;
 
 public slots:
   void setImage(kwiver::vital::image_container_sptr const& image,
@@ -67,7 +66,7 @@ public slots:
   void setHomography(QMatrix3x3 const& homography);
   void setZoom(float zoom);
   void setCenter(QPointF center);
-  void setVideoSource(core::VideoSource* videoSource);
+  void setVideoSource(core::VideoDistributor* videoSource);
   void setContrastMode(ContrastMode mode);
   void setManualLevels(float low, float high);
   void setPercentiles(double deviance, double tolerance);

--- a/sealtk/gui/PlayerControl.cpp
+++ b/sealtk/gui/PlayerControl.cpp
@@ -78,12 +78,8 @@ void PlayerControl::setVideoController(core::VideoController* videoController)
 
   if (d->videoController)
   {
-    disconnect(d->videoController, &core::VideoController::videoSourcesChanged,
-               this, &PlayerControl::setParamsFromVideoController);
-    disconnect(d->videoController, &core::VideoController::timeSelected,
-               this, &PlayerControl::setTime);
-    disconnect(this, &PlayerControl::timeSet,
-               d->videoController, &core::VideoController::seekNearest);
+    disconnect(d->videoController, nullptr, this, nullptr);
+    disconnect(this, nullptr, d->videoController, nullptr);
 
     d->videoController = nullptr;
   }
@@ -92,12 +88,14 @@ void PlayerControl::setVideoController(core::VideoController* videoController)
   {
     d->videoController = videoController;
 
-    connect(d->videoController, &core::VideoController::videoSourcesChanged,
+    connect(d->videoController, &core::VideoController::timesChanged,
             this, &PlayerControl::setParamsFromVideoController);
     connect(d->videoController, &core::VideoController::timeSelected,
             this, &PlayerControl::setTime);
-    connect(this, &PlayerControl::timeSet,
-            d->videoController, &core::VideoController::seekNearest);
+    connect(this, &PlayerControl::timeSet, d->videoController,
+            [d](kwiver::vital::timestamp::time_t time){
+              d->videoController->seekNearest(time, 0);
+            });
   }
 
   this->setParamsFromVideoController();
@@ -187,22 +185,11 @@ void PlayerControl::setParamsFromVideoController()
 
   if (d->videoController)
   {
-    auto times = d->videoController->times();
-    auto it = times.begin();
-    if (it != times.end())
+    auto const& times = d->videoController->times();
+    if (!times.isEmpty())
     {
-      kwiver::vital::timestamp::time_t min = *it, max = *it;
-      while (++it != times.end())
-      {
-        if (*it < min)
-        {
-          min = *it;
-        }
-        if (*it >max)
-        {
-          max = *it;
-        }
-      }
+      auto const min = times.begin().key();
+      auto const max = (--times.end()).key();
 
       this->setMin(min);
       this->setMax(max);

--- a/sealtk/noaa/core/ImageListVideoSourceFactory.cpp
+++ b/sealtk/noaa/core/ImageListVideoSourceFactory.cpp
@@ -25,7 +25,7 @@ QTE_IMPLEMENT_D_FUNC(ImageListVideoSourceFactory)
 
 // ----------------------------------------------------------------------------
 ImageListVideoSourceFactory::ImageListVideoSourceFactory(
-  bool directory, sealtk::core::VideoController* parent)
+  bool directory, QObject* parent)
   : sealtk::core::KwiverFileVideoSourceFactory{parent},
     d_ptr{new ImageListVideoSourceFactoryPrivate}
 {

--- a/sealtk/noaa/core/ImageListVideoSourceFactory.hpp
+++ b/sealtk/noaa/core/ImageListVideoSourceFactory.hpp
@@ -37,7 +37,7 @@ class SEALTK_NOAA_CORE_EXPORT ImageListVideoSourceFactory :
 
 public:
   explicit ImageListVideoSourceFactory(
-    bool directory, sealtk::core::VideoController* parent = nullptr);
+    bool directory, QObject* parent = nullptr);
   ~ImageListVideoSourceFactory() override;
 
   bool expectsDirectory() const override;

--- a/sealtk/noaa/gui/Player.cpp
+++ b/sealtk/noaa/gui/Player.cpp
@@ -45,12 +45,14 @@ Player::Player(QWidget* parent)
   connect(d->loadDetectionsAction, &QAction::triggered,
           this, &Player::loadDetectionsTriggered);
 
+  /* TODO
   connect(this, &sealtk::gui::Player::videoSourceChanged, this,
           [d](sealtk::core::VideoSource* videoSource){
             d->loadDetectionsAction->setEnabled(
               videoSource &&
               qobject_cast<sealtk::core::KwiverVideoSource*>(videoSource));
           });
+  */
 
   d->loadDetectionsAction->setEnabled(false);
 }

--- a/sealtk/noaa/gui/Window.cpp
+++ b/sealtk/noaa/gui/Window.cpp
@@ -38,11 +38,11 @@ namespace gui
 {
 
 //=============================================================================
-class WindowData
+struct WindowData
 {
-public:
-  sealtk::gui::SplitterWindow* window;
-  sealtk::noaa::gui::Player* player;
+  sealtk::core::VideoSource* videoSource = nullptr;
+  sealtk::gui::SplitterWindow* window = nullptr;
+  sealtk::noaa::gui::Player* player = nullptr;
 };
 
 //=============================================================================
@@ -64,8 +64,6 @@ public:
 
   WindowData eoWindow;
   WindowData irWindow;
-
-  bool firstWindow = true;
 
   float zoom = 1.0f;
   QPointF center{0.0f, 0.0f};
@@ -94,11 +92,14 @@ Window::Window(QWidget* parent)
 
   connect(d->ui.actionAbout, &QAction::triggered,
           this, &Window::showAbout);
-  connect(
-    d->ui.control, &sealtk::gui::PlayerControl::previousFrameTriggered,
-    d->videoController.get(), &sealtk::core::VideoController::previousFrame);
+  connect(d->ui.control, &sealtk::gui::PlayerControl::previousFrameTriggered,
+          this, [d]{
+            d->videoController->previousFrame(0);
+          });
   connect(d->ui.control, &sealtk::gui::PlayerControl::nextFrameTriggered,
-          d->videoController.get(), &sealtk::core::VideoController::nextFrame);
+          this, [d]{
+            d->videoController->nextFrame(0);
+          });
 
   d->registerVideoSourceFactory(
     "Image List File...",
@@ -179,34 +180,15 @@ void WindowPrivate::registerVideoSourceFactory(
     [this, q](void* handle, sealtk::core::VideoSource* videoSource)
   {
     auto* data = static_cast<WindowData*>(handle);
-    auto* oldVideoSource = data->player->videoSource();
-    data->player->setVideoSource(videoSource);
-    if (oldVideoSource)
-    {
-      delete oldVideoSource;
-    }
 
-    if (this->firstWindow)
-    {
-      this->firstWindow = false;
-      auto times = this->videoController->times();
-      auto it = times.begin();
-      if (it != times.end())
-      {
-        auto min = *it;
-        while (++it != times.end())
-        {
-          if (*it < min)
-          {
-            min = *it;
-          }
-        }
+    // If this view had a video source previously, delete it
+    delete data->videoSource;
 
-        this->videoController->seek(min);
-      }
-    }
-
-    videoSource->invalidate();
+    // Add the new video source
+    data->videoSource = videoSource;
+    auto* const videoDistributor =
+      this->videoController->addVideoSource(videoSource);
+    data->player->setVideoSource(videoDistributor);
   });
 
   auto* fileFactory =
@@ -215,23 +197,22 @@ void WindowPrivate::registerVideoSourceFactory(
   {
     QObject::connect(
       fileFactory, &sealtk::core::FileVideoSourceFactory::fileRequested,
-      [q, fileFactory](void* handle)
-    {
-      QString filename;
-      if (fileFactory->expectsDirectory())
-      {
-        filename = QFileDialog::getExistingDirectory(q);
-      }
-      else
-      {
-        filename = QFileDialog::getOpenFileName(q);
-      }
+      [q, fileFactory](void* handle){
+        QString filename;
+        if (fileFactory->expectsDirectory())
+        {
+          filename = QFileDialog::getExistingDirectory(q);
+        }
+        else
+        {
+          filename = QFileDialog::getOpenFileName(q);
+        }
 
-      if (!filename.isNull())
-      {
-        fileFactory->loadFile(handle, filename);
-      }
-    });
+        if (!filename.isNull())
+        {
+          fileFactory->loadFile(handle, filename);
+        }
+      });
   }
 }
 
@@ -275,7 +256,9 @@ void WindowPrivate::createWindow(WindowData* data, QString const& title)
         kwiver::vital::algo::detected_object_set_input
           ::set_nested_algo_configuration("input", config, input);
         input->open(stdString(filename));
+        /* TODO
         kwiverVideoSource->setDetectedObjectSetInput(input);
+        */
       }
     }
   });

--- a/sealtk/noaa/test/CMakeLists.txt
+++ b/sealtk/noaa/test/CMakeLists.txt
@@ -18,4 +18,5 @@ sealtk_add_test(ImageListVideoSourceFactory
 
   PRIVATE_LINK_LIBRARIES
     sealtk::noaa_core
+    sealtk::core_test_common
   )


### PR DESCRIPTION
This implements a new video API that a) is asynchronous, and b) supports multiple consumers. This will be especially important for running pipelines from within the GUI, as these need to be able to co-consume from video sources from a different thread.

For now, detection loading is disabled (the code is commented out). This needs to be rethought as a) it should not be as tightly coupled to the video source anyway, and b) my current thinking is that it would make sense to handle this sort of data via a `QAbstractItemModel`.

This fixes #19.