### PR TITLE
Hook up level control in Player

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,10 @@ find_package(Qt5 REQUIRED COMPONENTS
   Test
   Widgets
   Xml
+  Concurrent
+  Widgets
+  Gui
+  Core
   )
 find_package(qtExtensions REQUIRED)
 find_package(kwiver REQUIRED)

--- a/cmake/SEALTKUtils.cmake
+++ b/cmake/SEALTKUtils.cmake
@@ -51,6 +51,10 @@ function(sealtk_add_library name)
   if (sal_TYPE STREQUAL INTERFACE)
     add_library(${suffix} INTERFACE)
 
+    target_compile_features(${suffix}
+      INTERFACE cxx_lambda_init_captures
+      )
+
     target_link_libraries(${suffix}
       INTERFACE ${sal_PUBLIC_LINK_LIBRARIES}
       )
@@ -69,6 +73,10 @@ function(sealtk_add_library name)
       LIBRARY_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/${CMAKE_INSTALL_LIBDIR}"
       ARCHIVE_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/${CMAKE_INSTALL_LIBDIR}"
       OUTPUT_NAME "sealtk_${suffix}"
+      )
+
+    target_compile_features(${suffix}
+      PUBLIC cxx_lambda_init_captures
       )
 
     target_link_libraries(${suffix}

--- a/sealtk/gui/CMakeLists.txt
+++ b/sealtk/gui/CMakeLists.txt
@@ -22,5 +22,8 @@ sealtk_add_library(sealtk::gui
   PUBLIC_LINK_LIBRARIES
     sealtk::core
 
+  PRIVATE_LINK_LIBRARIES
+    Qt5::Concurrent
+
   EXPORT_HEADER Export.h
   )

--- a/sealtk/gui/Player.cpp
+++ b/sealtk/gui/Player.cpp
@@ -4,6 +4,7 @@
 
 #include <sealtk/gui/Player.hpp>
 
+#include <sealtk/core/AutoLevelsTask.hpp>
 #include <sealtk/core/ImageUtils.hpp>
 
 #include <sealtk/util/unique.hpp>
@@ -20,13 +21,23 @@
 #include <QVector2D>
 #include <QWheelEvent>
 
+#include <QtConcurrentRun>
+
 #include <cmath>
+
+namespace kv = kwiver::vital;
 
 namespace sealtk
 {
 
 namespace gui
 {
+
+struct LevelsPair
+{
+  float low;
+  float high;
+};
 
 struct VertexData
 {
@@ -45,16 +56,21 @@ public:
   void updateViewHomography();
   void updateDetectedObjectVertexBuffers();
 
-  void drawImage(QOpenGLFunctions* functions);
+  void drawImage(float levelShift, float levelScale,
+                 QOpenGLFunctions* functions);
   void drawDetections(QOpenGLFunctions* functions);
+
+  LevelsPair levels();
+  void computeLevels(LevelsPair const& temporaryLevels);
 
   QTE_DECLARE_PUBLIC(Player)
   QTE_DECLARE_PUBLIC_PTR(Player)
 
   QMetaObject::Connection destroyResourcesConnection;
 
-  kwiver::vital::image_container_sptr image;
-  kwiver::vital::detected_object_set_sptr detectedObjectSet;
+  kv::timestamp timeStamp;
+  kv::image_container_sptr image;
+  kv::detected_object_set_sptr detectedObjectSet;
   std::vector<std::unique_ptr<QOpenGLBuffer>> detectedObjectVertexBuffers;
   QMatrix3x3 homography;
   QMatrix4x4 homographyGl;
@@ -69,8 +85,17 @@ public:
   int imageViewHomographyLocation;
   int detectionHomographyLocation;
   int detectionViewHomographyLocation;
+  int levelShiftLocation;
+  int levelScaleLocation;
 
   bool initialized = false;
+
+  ContrastMode contrastMode = ContrastMode::Manual;
+  LevelsPair manualLevels{0.0f, 1.0f};
+  double percentileDeviance = 0.0078125;
+  double percentileTolerance = 0.5;
+  core::TimeMap<LevelsPair> percentileLevels;
+  quint64 percentileCookie = 0;
 
   QPointF center{0.0f, 0.0f};
   float zoom = 1.0f;
@@ -125,11 +150,13 @@ core::VideoSource* Player::videoSource() const
 }
 
 //-----------------------------------------------------------------------------
-void Player::setImage(kwiver::vital::image_container_sptr const& image)
+void Player::setImage(kv::image_container_sptr const& image,
+                      core::VideoMetaData const& metaData)
 {
   QTE_D();
 
   d->image = image;
+  d->timeStamp = metaData.timeStamp();
 
   this->makeCurrent();
   d->createTexture();
@@ -140,7 +167,7 @@ void Player::setImage(kwiver::vital::image_container_sptr const& image)
 
 //-----------------------------------------------------------------------------
 void Player::setDetectedObjectSet(
-  kwiver::vital::detected_object_set_sptr const& detectedObjectSet)
+  kv::detected_object_set_sptr const& detectedObjectSet)
 {
   QTE_D();
 
@@ -231,6 +258,61 @@ void Player::setVideoSource(core::VideoSource* videoSource)
 }
 
 //-----------------------------------------------------------------------------
+ContrastMode Player::contrastMode() const
+{
+  QTE_D();
+  return d->contrastMode;
+}
+
+//-----------------------------------------------------------------------------
+void Player::setContrastMode(ContrastMode newMode)
+{
+  QTE_D();
+  if (d->contrastMode != newMode)
+  {
+    d->contrastMode = newMode;
+    this->update();
+  }
+}
+
+//-----------------------------------------------------------------------------
+void Player::setManualLevels(float low, float high)
+{
+  QTE_D();
+
+  if (d->manualLevels.low != low || d->manualLevels.high != high)
+  {
+    d->manualLevels.low = low;
+    d->manualLevels.high = high;
+
+    if (d->contrastMode == ContrastMode::Manual)
+    {
+      this->update();
+    }
+  }
+}
+
+//-----------------------------------------------------------------------------
+void Player::setPercentiles(double deviance, double tolerance)
+{
+  QTE_D();
+
+  if (d->percentileDeviance != deviance ||
+      d->percentileTolerance != tolerance)
+  {
+    d->percentileDeviance = deviance;
+    d->percentileTolerance = tolerance;
+    d->percentileLevels.clear();
+    ++d->percentileCookie;
+
+    if (d->contrastMode == ContrastMode::Percentile)
+    {
+      this->update();
+    }
+  }
+}
+
+//-----------------------------------------------------------------------------
 void Player::initializeGL()
 {
   QTE_D();
@@ -259,6 +341,10 @@ void Player::initializeGL()
     d->imageShaderProgram.uniformLocation("homography");
   d->imageViewHomographyLocation =
     d->imageShaderProgram.uniformLocation("viewHomography");
+  d->levelShiftLocation =
+    d->imageShaderProgram.uniformLocation("levelShift");
+  d->levelScaleLocation =
+    d->imageShaderProgram.uniformLocation("levelScale");
 
   d->detectionShaderProgram.addShaderFromSourceFile(
     QOpenGLShader::Vertex, ":/DetectionVertex.glsl");
@@ -289,7 +375,11 @@ void Player::paintGL()
     functions->glClearColor(0.0f, 0.0f, 0.0f, 0.0f);
     functions->glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
 
-    d->drawImage(functions);
+    auto const levels = d->levels();
+    auto const levelShift = levels.low;
+    auto const levelScale = 1.0f / (levels.high - levels.low);
+
+    d->drawImage(levelShift, levelScale, functions);
     d->drawDetections(functions);
   }
   else
@@ -504,7 +594,82 @@ void PlayerPrivate::updateDetectedObjectVertexBuffers()
 }
 
 //-----------------------------------------------------------------------------
-void PlayerPrivate::drawImage(QOpenGLFunctions* functions)
+void PlayerPrivate::computeLevels(LevelsPair const& temporaryLevels)
+{
+  QTE_Q();
+
+  auto const t = this->timeStamp.get_time_usec();
+
+  // Set up task to compute percentile levels
+  auto const pd = this->percentileDeviance;
+  auto const pt = this->percentileTolerance;
+  auto* const task = new core::AutoLevelsTask{this->image, pd, pt};
+
+  // Hook up receipt of results from task
+  QObject::connect(
+    task, &core::AutoLevelsTask::levelsUpdated,
+    q, [t, cookie=this->percentileCookie, this](float low, float high){
+      if (this->percentileCookie == cookie)
+      {
+        // Update the entry in the map
+        this->percentileLevels.insert(t, {low, high});
+
+        // If the image whose levels we are updating is the currently displayed
+        // image, issue a repaint
+        if (this->timeStamp.get_time_usec() == t)
+        {
+          QTE_Q();
+          q->update();
+        }
+      }
+    });
+
+  // Run task
+  QtConcurrent::run(
+    [task]{
+      task->execute();
+      task->deleteLater();
+    });
+
+  // Insert a placeholder entry so we don't fire off the task twice
+  this->percentileLevels.insert(t, temporaryLevels);
+}
+
+//-----------------------------------------------------------------------------
+LevelsPair PlayerPrivate::levels()
+{
+  switch (this->contrastMode)
+  {
+    case ContrastMode::Percentile:
+      if (this->percentileLevels.isEmpty())
+      {
+        // No entries yet; schedule new task to compute levels for this image
+        this->computeLevels(this->manualLevels);
+        return this->manualLevels;
+      }
+      else
+      {
+        // Look up entry in levels map
+        auto const t = this->timeStamp.get_time_usec();
+        auto const i = this->percentileLevels.find(t, core::SeekNearest);
+        Q_ASSERT(i != this->percentileLevels.end());
+
+        if (i.key() != t)
+        {
+          // Inexact match; schedule new task to compute levels for this image
+          this->computeLevels(i.value());
+        }
+
+        return i.value();
+      }
+    default:
+      return this->manualLevels;
+  }
+}
+
+//-----------------------------------------------------------------------------
+void PlayerPrivate::drawImage(float levelShift, float levelScale,
+                              QOpenGLFunctions* functions)
 {
   this->imageShaderProgram.bind();
   this->imageTexture.bind();
@@ -522,6 +687,11 @@ void PlayerPrivate::drawImage(QOpenGLFunctions* functions)
                                                 &this->homographyGl, 1);
   this->imageShaderProgram.setUniformValueArray(
     this->imageViewHomographyLocation, &this->viewHomography, 1);
+
+  this->imageShaderProgram.setUniformValue(
+    this->levelShiftLocation, levelShift);
+  this->imageShaderProgram.setUniformValue(
+    this->levelScaleLocation, levelScale);
 
   functions->glDrawArrays(GL_TRIANGLE_FAN, 0, 4);
 

--- a/sealtk/gui/Player.hpp
+++ b/sealtk/gui/Player.hpp
@@ -25,6 +25,16 @@ namespace sealtk
 namespace gui
 {
 
+Q_NAMESPACE
+
+enum class ContrastMode
+{
+  Manual,
+  Percentile,
+};
+
+Q_ENUM_NS(ContrastMode)
+
 class PlayerPrivate;
 
 class SEALTK_GUI_EXPORT Player : public QOpenGLWidget
@@ -37,10 +47,12 @@ public:
 
   Q_PROPERTY(float zoom READ zoom WRITE setZoom NOTIFY zoomChanged);
   Q_PROPERTY(QPointF center READ center WRITE setCenter NOTIFY centerChanged);
+  Q_PROPERTY(ContrastMode contrastMode READ contrastMode WRITE setContrastMode)
 
   float zoom() const;
   QPointF center() const;
   core::VideoSource* videoSource() const;
+  ContrastMode contrastMode() const;
 
 signals:
   void zoomChanged(float zoom) const;
@@ -48,13 +60,17 @@ signals:
   void videoSourceChanged(core::VideoSource* videoSource) const;
 
 public slots:
-  void setImage(kwiver::vital::image_container_sptr const& image);
+  void setImage(kwiver::vital::image_container_sptr const& image,
+                sealtk::core::VideoMetaData const& metaData);
   void setDetectedObjectSet(
     kwiver::vital::detected_object_set_sptr const& detectedObjectSet);
   void setHomography(QMatrix3x3 const& homography);
   void setZoom(float zoom);
   void setCenter(QPointF center);
   void setVideoSource(core::VideoSource* videoSource);
+  void setContrastMode(ContrastMode mode);
+  void setManualLevels(float low, float high);
+  void setPercentiles(double deviance, double tolerance);
 
 protected:
   QTE_DECLARE_PRIVATE(Player)

--- a/sealtk/gui/resources/PlayerFragment.glsl
+++ b/sealtk/gui/resources/PlayerFragment.glsl
@@ -5,6 +5,8 @@
 #version 130
 
 uniform sampler2DArray image;
+uniform float levelShift;
+uniform float levelScale;
 
 in vec2 v_textureCoords;
 
@@ -13,4 +15,5 @@ out vec4 color;
 void main()
 {
   color = texture(image, vec3(v_textureCoords, 0));
+  color = clamp((color - levelShift) * levelScale, 0.0, 1.0);
 }

--- a/sealtk/noaa/gui/Window.cpp
+++ b/sealtk/noaa/gui/Window.cpp
@@ -85,6 +85,10 @@ Window::Window(QWidget* parent)
   d->createWindow(&d->eoWindow, QStringLiteral("EO Imagery"));
   d->createWindow(&d->irWindow, QStringLiteral("IR Imagery"));
 
+  d->eoWindow.player->setContrastMode(::sealtk::gui::ContrastMode::Manual);
+  d->irWindow.player->setContrastMode(::sealtk::gui::ContrastMode::Percentile);
+  d->irWindow.player->setPercentiles(0.0, 1.0);
+
   d->videoController = make_unique<sealtk::core::VideoController>(this);
   d->ui.control->setVideoController(d->videoController.get());
 


### PR DESCRIPTION
Add new "contrast mode" options to `gui::Player`. The options are `Manual` (user specifies minimum and maximum values) and `Percentile` (uses `AutoLevelsTask` to compute values). This also includes the logic to keep track of computed percentile levels per time-keyed image, and to fire off new tasks as needed.

Modify NOAA GUI to use Percentile mode for the IR view. (For now, this is hard-coded, as are the tolerance and deviation values.)