### PR TITLE
Add conversions to date/time strings

### DIFF
--- a/sealtk/core/DateUtils.cpp
+++ b/sealtk/core/DateUtils.cpp
@@ -10,18 +10,44 @@ namespace sealtk
 namespace core
 {
 
+// ----------------------------------------------------------------------------
 QDateTime vitalTimeToQDateTime(kwiver::vital::timestamp::time_t time)
 {
   qint64 ms = time / 1000;
   return QDateTime::fromMSecsSinceEpoch(ms, Qt::UTC);
 }
 
+// ----------------------------------------------------------------------------
 kwiver::vital::timestamp::time_t qDateTimeToVitalTime(
   QDateTime const& dateTime)
 {
   return dateTime.toMSecsSinceEpoch() * 1000;
 }
 
+// ----------------------------------------------------------------------------
+QString dateString(QDateTime const& dateTime)
+{
+  return dateTime.toUTC().toString("yyyy-MM-dd");
 }
 
+// ----------------------------------------------------------------------------
+QString dateString(kwiver::vital::timestamp::time_t time)
+{
+  return dateString(vitalTimeToQDateTime(time));
 }
+
+// ----------------------------------------------------------------------------
+QString timeString(QDateTime const& dateTime)
+{
+  return dateTime.toUTC().toString("hh:mm:ss.zzz");
+}
+
+// ----------------------------------------------------------------------------
+QString timeString(kwiver::vital::timestamp::time_t time)
+{
+  return timeString(vitalTimeToQDateTime(time));
+}
+
+} // namespace core
+
+} // namespace sealtk

--- a/sealtk/core/DateUtils.hpp
+++ b/sealtk/core/DateUtils.hpp
@@ -24,8 +24,20 @@ SEALTK_CORE_EXPORT
 kwiver::vital::timestamp::time_t qDateTimeToVitalTime(
   QDateTime const& dateTime);
 
-}
+SEALTK_CORE_EXPORT
+QString dateString(QDateTime const& dateTime);
 
-}
+SEALTK_CORE_EXPORT
+QString dateString(kwiver::vital::timestamp::time_t time);
+
+SEALTK_CORE_EXPORT
+QString timeString(QDateTime const& dateTime);
+
+SEALTK_CORE_EXPORT
+QString timeString(kwiver::vital::timestamp::time_t time);
+
+} // namespace core
+
+} // namespace sealtk
 
 #endif

--- a/sealtk/core/test/DateUtils.cpp
+++ b/sealtk/core/test/DateUtils.cpp
@@ -28,6 +28,10 @@ private slots:
   void vitalTimeToQDateTime_data();
   void qDateTimeToVitalTime();
   void qDateTimeToVitalTime_data();
+  void dateString();
+  void dateString_data();
+  void timeString();
+  void timeString_data();
 };
 
 // ----------------------------------------------------------------------------
@@ -76,11 +80,63 @@ void TestDateUtils::qDateTimeToVitalTime_data()
     << 1381481842745000l;
 }
 
+// ----------------------------------------------------------------------------
+void TestDateUtils::dateString()
+{
+  QFETCH(QDateTime, input);
+  QFETCH(QString, expected);
+
+  QCOMPARE(core::dateString(input), expected);
 }
 
+// ----------------------------------------------------------------------------
+void TestDateUtils::dateString_data()
+{
+  QTest::addColumn<QDateTime>("input");
+  QTest::addColumn<QString>("expected");
+
+  QTest::newRow("zero")
+    << QDateTime{{1970, 1, 1}, {0, 0, 0}, Qt::UTC}
+    << QStringLiteral("1970-01-01");
+  QTest::newRow("sample1")
+    << QDateTime{{1987, 4, 14}, {16, 23, 47, 289}, Qt::UTC}
+    << QStringLiteral("1987-04-14");
+  QTest::newRow("sample2")
+    << QDateTime{{2013, 10, 11}, {8, 57, 22, 745}, Qt::UTC}
+    << QStringLiteral("2013-10-11");
 }
 
+// ----------------------------------------------------------------------------
+void TestDateUtils::timeString()
+{
+  QFETCH(QDateTime, input);
+  QFETCH(QString, expected);
+
+  QCOMPARE(core::timeString(input), expected);
 }
+
+// ----------------------------------------------------------------------------
+void TestDateUtils::timeString_data()
+{
+  QTest::addColumn<QDateTime>("input");
+  QTest::addColumn<QString>("expected");
+
+  QTest::newRow("zero")
+    << QDateTime{{1970, 1, 1}, {0, 0, 0}, Qt::UTC}
+    << QStringLiteral("00:00:00.000");
+  QTest::newRow("sample1")
+    << QDateTime{{1987, 4, 14}, {16, 23, 47, 289}, Qt::UTC}
+    << QStringLiteral("16:23:47.289");
+  QTest::newRow("sample2")
+    << QDateTime{{2013, 10, 11}, {8, 57, 22, 745}, Qt::UTC}
+    << QStringLiteral("08:57:22.745");
+}
+
+} // namespace test
+
+} // namespace core
+
+} // namespace sealtk
 
 QTEST_MAIN(sealtk::core::test::TestDateUtils)
 #include "DateUtils.moc"


### PR DESCRIPTION
Add additional convenience methods to convert a `timestamp::time_t` or `QDateTime` to a string representing either the date or the time as text. These will be useful for UI's that want to show date/time to the user.