### PR TITLE
Create base classes for item data

### DIFF
--- a/sealtk/core/CMakeLists.txt
+++ b/sealtk/core/CMakeLists.txt
@@ -12,6 +12,7 @@ set(SEALTK_CORE_VERSION_OUT
 sealtk_add_library(sealtk::core
   SOURCES
     AutoLevelsTask.cpp
+    DataModelTypes.cpp
     DateUtils.cpp
     FileVideoSourceFactory.cpp
     ImageUtils.cpp
@@ -25,6 +26,7 @@ sealtk_add_library(sealtk::core
 
   HEADERS
     AutoLevelsTask.hpp
+    DataModelTypes.hpp
     DateUtils.hpp
     FileVideoSourceFactory.hpp
     ImageUtils.hpp

--- a/sealtk/core/DataModelTypes.cpp
+++ b/sealtk/core/DataModelTypes.cpp
@@ -1,0 +1,1 @@
+// This file exists solely to trigger automoc for the corresponding header

--- a/sealtk/core/DataModelTypes.hpp
+++ b/sealtk/core/DataModelTypes.hpp
@@ -1,0 +1,88 @@
+/* This file is part of SEAL-TK, and is distributed under the OSI-approved BSD
+ * 3-Clause License. See top-level LICENSE file or
+ * https://github.com/Kitware/seal-tk/blob/master/LICENSE for details. */
+
+#ifndef sealtk_core_DataModelTypes_hpp
+#define sealtk_core_DataModelTypes_hpp
+
+#include <QMetaType>
+
+namespace sealtk
+{
+
+namespace core
+{
+
+Q_NAMESPACE
+
+/// Well known item types.
+enum ItemType
+{
+  InvalidItemType = 0,
+  TrackItem       = 0x01,
+  EventItem       = 0x02,
+  ActivityItem    = 0x04,
+  QueryResultItem = 0x08,
+  RegionItem      = 0x10,
+  AnnotationItem  = 0x20,
+  BuiltinItems    = 0x2f
+};
+
+Q_ENUM_NS(ItemType)
+
+/// Set of well known item types.
+Q_DECLARE_FLAGS(ItemTypes, ItemType)
+
+/// Common data roles for item data models.
+///
+/// This enumeration defines a number of standard data roles used by item
+/// representations. Item data models used to feed representations are expected
+/// to provide a subset of these data roles as determined by the specific
+/// representations being used.
+enum ItemDataRole
+{
+  /// (QString) Name or ID of the item as it should be displayed to the user.
+  NameRole = Qt::DisplayRole,
+
+  /// (ItemType) Type of the item.
+  ItemTypeRole = Qt::UserRole,
+
+  /// (\em varies) Logical ID of the item.
+  ///
+  /// The data type depends on the item type. Usually this will match or
+  /// contain the ID that the item was given by the source that produced the
+  /// item, and may contain a reference to the item's source.
+  LogicalIdentityRole,
+  /// (QUuid) Universally unique identifier of the item.
+  UniqueIdentityRole,
+
+  /// (bool) Effective visibility state of the item.
+  ///
+  /// This is \c true if the item's user visibility is \c true, and the item
+  /// has not been excluded by a filter.
+  VisibilityRole,
+
+  /// (bool) User override visibility state of the item.
+  ///
+  /// This is \c false iff the user has manually specified that this specific
+  /// item should be hidden.
+  UserVisibilityRole,
+
+  /// (timestamp::time_t) Scene time at which the item enters scope.
+  StartTimeRole,
+  /// (timestamp::time_t) Scene time at which the item leaves scope.
+  EndTimeRole,
+
+  /// First role that can be used for model-specific purposes.
+  UserRole = Qt::UserRole + 224
+};
+
+Q_ENUM_NS(ItemDataRole)
+
+} // namespace core
+
+} // namespace sealtk
+
+Q_DECLARE_OPERATORS_FOR_FLAGS(sealtk::core::ItemTypes)
+
+#endif

--- a/sealtk/gui/AbstractItemModel.cpp
+++ b/sealtk/gui/AbstractItemModel.cpp
@@ -1,0 +1,69 @@
+/* This file is part of SEAL-TK, and is distributed under the OSI-approved BSD
+ * 3-Clause License. See top-level LICENSE file or
+ * https://github.com/Kitware/seal-tk/blob/master/LICENSE for details. */
+
+#include <sealtk/gui/AbstractItemModel.hpp>
+
+#include <sealtk/core/DataModelTypes.hpp>
+#include <sealtk/core/DateUtils.hpp>
+
+#include <QHash>
+#include <QPalette>
+#include <QUuid>
+
+namespace kv = kwiver::vital;
+
+namespace sealtk
+{
+
+namespace gui
+{
+
+// ----------------------------------------------------------------------------
+int AbstractItemModel::columnCount(QModelIndex const& parent) const
+{
+  Q_UNUSED(parent);
+
+  // NOTE:
+  //
+  // If the model is filtered prior to being fed to a representation (which is
+  // often the case), QSortFilterProxyModel needs to reserve a QVector<int> of
+  // this size, or the final representation will end up truncated to this
+  // number of columns. Therefore, we need to return a value that is "not too
+  // large", but likely to be at least as large as the maximum number of
+  // columns that any representation will have.
+  return 64;
+}
+
+// ----------------------------------------------------------------------------
+QModelIndex AbstractItemModel::index(
+  int row, int column, QModelIndex const& parent) const
+{
+  return (parent.isValid() ? QModelIndex{} : this->createIndex(row, column));
+}
+
+// ----------------------------------------------------------------------------
+QModelIndex AbstractItemModel::parent(QModelIndex const& child) const
+{
+  Q_UNUSED(child);
+  return {};
+}
+
+// ----------------------------------------------------------------------------
+QVariant AbstractItemModel::data(QModelIndex const& index, int role) const
+{
+  if (role == core::VisibilityRole)
+  {
+    // VisibilityRole is meant to be defined by filters based on whatever
+    // filtering criteria they are using. Models notionally should not provide
+    // this role directly. However, this will break if a model is used without
+    // a filter, so by default, map VisibilityRole to UserVisibilityRole.
+    return this->data(index, core::UserVisibilityRole);
+  }
+
+  return {};
+}
+
+} // namespace gui
+
+} // namespace sealtk

--- a/sealtk/gui/AbstractItemModel.hpp
+++ b/sealtk/gui/AbstractItemModel.hpp
@@ -1,0 +1,50 @@
+/* This file is part of SEAL-TK, and is distributed under the OSI-approved BSD
+ * 3-Clause License. See top-level LICENSE file or
+ * https://github.com/Kitware/seal-tk/blob/master/LICENSE for details. */
+
+#ifndef sealtk_gui_AbstractItemModel_hpp
+#define sealtk_gui_AbstractItemModel_hpp
+
+#include <sealtk/gui/Export.h>
+
+#include <QAbstractItemModel>
+
+namespace sealtk
+{
+
+namespace gui
+{
+
+/// Abstract implementation of an item model.
+///
+/// This class provides a base class for implementing generic item data models.
+/// It provides common implementations of functions that are not likely to
+/// differ across different models, such as index creation and "column count".
+/// (The latter is useful because generic data models use role rather than
+/// column for field discrimination. Accordingly, the "column count" is
+/// determined by the representation which ultimately consumes the model,
+/// rather than the model itself.)
+///
+/// The default implementations of #index and #parent are suitable for "flat"
+/// models. Models that provide tree-structured data should override these.
+class SEALTK_GUI_EXPORT AbstractItemModel : public QAbstractItemModel
+{
+  Q_OBJECT
+
+public:
+  using QAbstractItemModel::QAbstractItemModel;
+
+  // Reimplemented from QAbstractItemModel
+  int columnCount(QModelIndex const& parent) const override;
+  QModelIndex index(
+    int row, int column, QModelIndex const& parent) const override;
+  QModelIndex parent(QModelIndex const& child) const override;
+
+  QVariant data(QModelIndex const& index, int role) const override;
+};
+
+} // namespace gui
+
+} // namespace sealtk
+
+#endif

--- a/sealtk/gui/AbstractItemRepresentation.cpp
+++ b/sealtk/gui/AbstractItemRepresentation.cpp
@@ -1,0 +1,399 @@
+/* This file is part of SEAL-TK, and is distributed under the OSI-approved BSD
+ * 3-Clause License. See top-level LICENSE file or
+ * https://github.com/Kitware/seal-tk/blob/master/LICENSE for details. */
+
+#include <sealtk/gui/AbstractItemRepresentation.hpp>
+
+#include <sealtk/core/DataModelTypes.hpp>
+#include <sealtk/core/DateUtils.hpp>
+
+#include <QHash>
+#include <QPalette>
+#include <QUuid>
+
+namespace kv = kwiver::vital;
+
+namespace sealtk
+{
+
+namespace gui
+{
+
+// ============================================================================
+class AbstractItemRepresentationPrivate
+{
+public:
+  QVector<int> columnRoles;
+
+  bool sortNeeded = false;
+  ItemVisibilityMode visibilityMode = OmitHidden;
+};
+
+// ----------------------------------------------------------------------------
+QTE_IMPLEMENT_D_FUNC(AbstractItemRepresentation)
+
+// ----------------------------------------------------------------------------
+AbstractItemRepresentation::AbstractItemRepresentation(QObject* parent)
+  : QSortFilterProxyModel{parent}, d_ptr{new AbstractItemRepresentationPrivate}
+{
+  // Our filtering (and likely that of our subclasses) is dependent on the
+  // logical data model's data; therefore, we need to re-filter and/or re-sort
+  // when the underlying data changes, and so we enable doing so by default
+  this->setDynamicSortFilter(true);
+}
+
+// ----------------------------------------------------------------------------
+AbstractItemRepresentation::~AbstractItemRepresentation()
+{
+}
+
+// ----------------------------------------------------------------------------
+int AbstractItemRepresentation::roleForColumn(int column) const
+{
+  QTE_D();
+  return d->columnRoles.value(column, -1);
+}
+
+// ----------------------------------------------------------------------------
+void AbstractItemRepresentation::setColumnRoles(
+  std::initializer_list<int> const& roles)
+{
+  QTE_D();
+  d->columnRoles = roles;
+}
+
+// ----------------------------------------------------------------------------
+ItemVisibilityMode AbstractItemRepresentation::itemVisibilityMode() const
+{
+  QTE_D();
+  return d->visibilityMode;
+}
+
+// ----------------------------------------------------------------------------
+void AbstractItemRepresentation::setItemVisibilityMode(ItemVisibilityMode mode)
+{
+  QTE_D();
+
+  if (d->visibilityMode != mode)
+  {
+    d->visibilityMode = mode;
+    this->invalidateFilter();
+  }
+}
+
+// ----------------------------------------------------------------------------
+int AbstractItemRepresentation::columnCount(QModelIndex const& parent) const
+{
+  QTE_D();
+
+  Q_UNUSED(parent);
+  return d->columnRoles.size();
+}
+
+// ----------------------------------------------------------------------------
+QVariant AbstractItemRepresentation::data(
+  QModelIndex const& index, int role) const
+{
+  if (index.isValid() && this->sourceModel())
+  {
+    switch (role)
+    {
+      case Qt::DisplayRole:
+      case Qt::DecorationRole:
+      case Qt::TextAlignmentRole:
+      case Qt::ToolTipRole:
+      {
+        QTE_D();
+        auto const c = index.column();
+        if (c < d->columnRoles.size())
+        {
+          return this->data(this->mapToSource(index), role,
+                            d->columnRoles[c]);
+        }
+        break;
+      }
+
+      case Qt::ForegroundRole:
+        if (!this->sourceData(index, core::VisibilityRole).toBool())
+        {
+          // Gray out hidden items
+          return QPalette().brush(QPalette::Disabled, QPalette::WindowText);
+        }
+        break;
+
+      default:
+        if (role >= core::ItemTypeRole && role < core::UserRole)
+        {
+          // Requests for logical data roles are passed through
+          return this->sourceData(index, role);
+        }
+        break;
+    }
+  }
+
+  return QSortFilterProxyModel::data(index, role);
+}
+
+// ----------------------------------------------------------------------------
+QVariant AbstractItemRepresentation::data(
+  QModelIndex const& sourceIndex, int presentationRole, int dataRole) const
+{
+  if (!sourceIndex.isValid() || !this->sourceModel())
+  {
+    return {};
+  }
+
+  auto* const sm = this->sourceModel();
+
+  switch (presentationRole)
+  {
+    case Qt::ToolTipRole:
+      switch (dataRole)
+      {
+        case core::StartTimeRole:
+        case core::EndTimeRole:
+        {
+          auto const& dt = core::vitalTimeToQDateTime(
+            sm->data(sourceIndex, dataRole).value<kv::timestamp::time_t>());
+          auto const& ds = core::dateString(dt);
+          auto const& ts = core::timeString(dt);
+          return QStringLiteral("%1 %2").arg(ds, ts);
+        }
+
+        // TODO classification, confidence
+
+        default:
+          break;
+      }
+
+      // If tool tip was not handled by above, fall through and use display
+      // text as tool tip
+      Q_FALLTHROUGH();
+
+    case Qt::DisplayRole:
+      switch (dataRole)
+      {
+        case core::ItemTypeRole:
+          break; // TODO
+
+        case core::NameRole:
+          return sm->data(sourceIndex, dataRole);
+
+        case core::UniqueIdentityRole:
+        {
+          auto const& uuid = sm->data(sourceIndex, dataRole).value<QUuid>();
+          return (uuid.isNull() ? QStringLiteral("(null)") : uuid.toString());
+        }
+
+        case core::StartTimeRole:
+        case core::EndTimeRole:
+        {
+          return core::timeString(
+            sm->data(sourceIndex, dataRole).value<kv::timestamp::time_t>());
+        }
+
+        // TODO classification, confidence
+
+        default:
+          break;
+      }
+      break;
+
+    case Qt::DecorationRole:
+      // TODO
+      break;
+
+    case Qt::TextAlignmentRole:
+      // TODO
+      break;
+
+    default:
+      break;
+  }
+
+  return {};
+}
+
+// ----------------------------------------------------------------------------
+QVariant AbstractItemRepresentation::headerData(
+  int section, Qt::Orientation orientation, int role) const
+{
+  QTE_D();
+
+  if (orientation == Qt::Horizontal &&
+      section >= 0 && section < d->columnRoles.size())
+  {
+    switch (role)
+    {
+      case Qt::DisplayRole:
+        switch (d->columnRoles[section])
+        {
+          case core::ItemTypeRole:        return QStringLiteral("Type");
+          case core::NameRole:            return QStringLiteral("Name");
+          case core::LogicalIdentityRole: return QStringLiteral("ID");
+          case core::UniqueIdentityRole:  return QStringLiteral("UUID");
+          case core::StartTimeRole:       return QStringLiteral("Start Time");
+          case core::EndTimeRole:         return QStringLiteral("End Time");
+          default: return {};
+        }
+        Q_UNREACHABLE();
+        break;
+
+      case Qt::DecorationRole:
+        return {};
+
+      default:
+        break;
+    }
+  }
+
+  return QSortFilterProxyModel::headerData(section, orientation, role);
+}
+
+// ----------------------------------------------------------------------------
+bool AbstractItemRepresentation::lessThan(
+  QModelIndex const& left, QModelIndex const& right) const
+{
+  QTE_D();
+
+  auto const c = left.column();
+  Q_ASSERT(c == right.column());
+  Q_ASSERT(c >= 0);
+
+  if (c < d->columnRoles.size())
+  {
+    auto const dataRole = d->columnRoles[c];
+    return this->lessThan(left, right, dataRole);
+  }
+
+  return QSortFilterProxyModel::lessThan(left, right);
+}
+
+// ----------------------------------------------------------------------------
+bool AbstractItemRepresentation::lessThan(
+  QModelIndex const& left, QModelIndex const& right, int role) const
+{
+  if (!this->sourceModel())
+  {
+    return false;
+  }
+
+  Q_ASSERT(left.column() == right.column());
+
+  auto* const sm = this->sourceModel();
+  auto const& leftData = sm->data(left, role);
+  auto const& rightData = sm->data(right, role);
+
+  switch (role)
+  {
+    // String comparisons
+    case core::NameRole:
+    case core::UniqueIdentityRole:
+      return QString::localeAwareCompare(leftData.toString(),
+                                         rightData.toString());
+
+    // Boolean comparisons
+    case core::VisibilityRole:
+    case core::UserVisibilityRole:
+      return leftData.toBool() < rightData.toBool();
+
+    // Integer comparisons
+    // TODO classification
+    case core::ItemTypeRole:
+      return leftData.toInt() < rightData.toInt();
+
+    // Floating-point comparisons
+    // TODO confidence
+    //   return leftData.toDouble() < rightData.toDouble();
+
+    // Timestamp comparisons
+    case core::StartTimeRole:
+    case core::EndTimeRole:
+    {
+      auto const lt = leftData.value<kv::timestamp::time_t>();
+      auto const rt = rightData.value<kv::timestamp::time_t>();
+      return lt < rt;
+    }
+
+    default:
+      return false;
+  }
+}
+
+// ----------------------------------------------------------------------------
+bool AbstractItemRepresentation::filterAcceptsRow(
+  int sourceRow, QModelIndex const& sourceParent) const
+{
+  QTE_D();
+
+  auto* const sm = this->sourceModel();
+  if (sm && d->visibilityMode == OmitHidden)
+  {
+    auto const& si = sm->index(sourceRow, 0, sourceParent);
+
+    if (!sm->data(si, core::VisibilityRole).toBool())
+    {
+      return false;
+    }
+  }
+
+  return QSortFilterProxyModel::filterAcceptsRow(sourceRow, sourceParent);
+}
+
+// ----------------------------------------------------------------------------
+bool AbstractItemRepresentation::filterAcceptsColumn(
+  int sourceColumn, QModelIndex const& sourceParent) const
+{
+  if (this->columnCount(this->mapFromSource(sourceParent)) < sourceColumn)
+  {
+    // The underlying model is expected to only "really" have one column, since
+    // data roles are used to get data that is mapped to display columns by the
+    // proxy model, but to claim to have a large number of columns because
+    // QSortFilterProxyModel will only show a maximum of the source model's
+    // columnCount() columns. Therefore, by default we ignore columns whose
+    // index is greater than our column count, which should be equal to the
+    // number of columns that we actually map.
+    return false;
+  }
+
+  return QSortFilterProxyModel::filterAcceptsColumn(
+    sourceColumn, sourceParent);
+}
+
+// ----------------------------------------------------------------------------
+void AbstractItemRepresentation::sort(int column, Qt::SortOrder order)
+{
+  QTE_D();
+
+  QSortFilterProxyModel::sort(column, order);
+
+  // Determine, if we are sorting (column >= 0), if QSortFilterProxyModel
+  // figured out what column to sort; if not, we may need to force a sort later
+  d->sortNeeded =
+    column >= 0 && !this->mapToSource(this->index(0, column, {})).isValid();
+}
+
+// ----------------------------------------------------------------------------
+void AbstractItemRepresentation::updateSort()
+{
+  QTE_D();
+
+  // Our data has changed; if we previously failed to sort...
+  if (d->sortNeeded)
+  {
+    // ...then attempt to do so now (if dynamic sorting is enabled)
+    if (this->dynamicSortFilter())
+    {
+      // NOTE: Must clear dynamic sort filter first or sort() will decline to
+      //       actually do anything; this ends up sorting twice, but there
+      //       doesn't seem to be any way around that
+      this->setDynamicSortFilter(false);
+      this->sort(this->sortColumn(), this->sortOrder());
+      this->setDynamicSortFilter(true);
+    }
+  }
+}
+
+} // namespace gui
+
+} // namespace sealtk

--- a/sealtk/gui/AbstractItemRepresentation.hpp
+++ b/sealtk/gui/AbstractItemRepresentation.hpp
@@ -1,0 +1,169 @@
+/* This file is part of SEAL-TK, and is distributed under the OSI-approved BSD
+ * 3-Clause License. See top-level LICENSE file or
+ * https://github.com/Kitware/seal-tk/blob/master/LICENSE for details. */
+
+#ifndef sealtk_gui_AbstractItemRepresentation_hpp
+#define sealtk_gui_AbstractItemRepresentation_hpp
+
+#include <sealtk/gui/Export.h>
+
+#include <qtGlobal.h>
+
+#include <QSortFilterProxyModel>
+
+namespace sealtk
+{
+
+namespace gui
+{
+
+Q_NAMESPACE
+
+/// Item visibility mode.
+///
+/// This enumeration specifies how "hidden" items will be manipulated by the
+/// representation.
+enum ItemVisibilityMode
+{
+  /// "Hidden" items are not shown.
+  OmitHidden,
+  /// "Hidden" items are shown in an alternate ("grayed out") color.
+  ShadowHidden,
+};
+
+Q_ENUM_NS(ItemVisibilityMode)
+
+class AbstractItemRepresentationPrivate;
+
+/// Abstract implementation of an item representation.
+///
+/// This class provides a base class for implementing item representations from
+/// a generic data model. It provides some common functionality for translating
+/// low-level data types into data suitable for presentation, as well as common
+/// handling for handling and manipulating item visibility states.
+class SEALTK_GUI_EXPORT AbstractItemRepresentation
+  : public QSortFilterProxyModel
+{
+  Q_OBJECT
+
+  /// This property specifies the visibility mode for "hidden" items.
+  ///
+  /// This property controls the presentation of items which are "hidden"
+  /// (that is, the item data for VisibilityRole is \c false).
+  ///
+  /// \sa ItemVisibilityMode, itemVisibilityMode(), setItemVisibilityMode()
+  Q_PROPERTY(ItemVisibilityMode itemVisibilityMode
+             READ itemVisibilityMode
+             WRITE setItemVisibilityMode)
+
+public:
+  explicit AbstractItemRepresentation(QObject* parent = nullptr);
+  ~AbstractItemRepresentation() override;
+
+  /// Get the visibility mode for "hidden" items.
+  /// \sa ItemVisibilityMode, itemVisibilityMode, setItemVisibilityMode()
+  virtual ItemVisibilityMode itemVisibilityMode() const;
+
+  /// Get data role mapping for column.
+  ///
+  /// This returns the data role mapping (i.e. the logical data role) for the
+  /// specified column, or -1 if no mapping has been set.
+  ///
+  /// This is not used internally, but may be used by e.g. views in order to
+  /// take appropriate actions when an item index is activated or edited. As
+  /// such, subclasses should override this method if necessary to ensure that
+  /// a suitable logical role is always returned whenever possible.
+  virtual int roleForColumn(int column) const;
+
+  // Reimplemented from QAbstractItemModel
+  int columnCount(QModelIndex const& parent = {}) const override;
+  QVariant data(QModelIndex const& index, int role) const override;
+  QVariant headerData(int section, Qt::Orientation orientation,
+                      int role = Qt::DisplayRole) const override;
+
+  // Reimplemented from QSortFilterProxyModel
+  void sort(int column, Qt::SortOrder order = Qt::AscendingOrder) override;
+
+public slots:
+  /// Set the visibility mode for "hidden" items.
+  /// \sa ItemVisibilityMode, itemVisibilityMode, itemVisibilityMode()
+  virtual void setItemVisibilityMode(ItemVisibilityMode);
+
+protected slots:
+  /// Update sorting when data changes.
+  ///
+  /// This slot checks if the model has not been sorted, and if so, sorts it.
+  /// This is done to work around a bug in QSortFilterProxyModel where items
+  /// are not sorted after a data change if all items were initially hidden.
+  ///
+  /// This slot is called automatically when the proxy model's data changes
+  /// (note: \em not the source model's data). Users should not normally need
+  /// to call this slot themselves.
+  void updateSort();
+
+protected:
+  QTE_DECLARE_PRIVATE_RPTR(AbstractItemRepresentation)
+
+  /// Set data role mappings for columns.
+  ///
+  /// This sets a data role mapping for all columns, which also sets the
+  /// representation's column count. Calls to #data(QModelIndex const&, int)
+  /// and #lessThan(QModelIndex const&, QModelIndex const&) will return or use
+  /// the data for the specified logical data role.
+  virtual void setColumnRoles(std::initializer_list<int> const& roles);
+
+  /// Return representation for specified index and data role.
+  ///
+  /// This method returns presentation-ready data for the specified
+  /// presentation role and data role.
+  ///
+  /// Supported presentation roles are:
+  /// \li Qt::DisplayRole
+  /// \li Qt::DecorationRole
+  /// \li Qt::TextAlignmentRole
+  /// \li Qt::ToolTipRole
+  virtual QVariant data(
+    QModelIndex const& sourceIndex, int presentationRole, int dataRole) const;
+
+  /// Obtain data from source model.
+  ///
+  /// This is a convenience function to obtain data from the source model,
+  /// using an index from this model.
+  inline QVariant sourceData(QModelIndex const& index, int role) const
+  {
+    auto* const sm = this->sourceModel();
+    auto const& si = this->mapToSource(index);
+    Q_ASSERT(sm);
+
+    return sm->data(si, role);
+  }
+
+  /// Compare data for two indices.
+  ///
+  /// This method performs a comparison of the \p role data of two proxy
+  /// indices. If \p role is not a supported data role, the result is \c false.
+  ///
+  /// \return \c true if the left index's data is less than the right index's
+  ///         data; otherwise \c false.
+  virtual bool lessThan(
+    QModelIndex const& left, QModelIndex const& right, int role) const;
+
+  // Reimplemented from QSortFilterProxyModel
+  bool lessThan(
+    QModelIndex const& left, QModelIndex const& right) const override;
+
+  // Reimplemented from QSortFilterProxyModel
+  bool filterAcceptsRow(
+    int sourceRow, QModelIndex const& sourceParent) const override;
+  bool filterAcceptsColumn(
+    int source_column, QModelIndex const& source_parent) const override;
+
+private:
+  QTE_DECLARE_PRIVATE(AbstractItemRepresentation)
+};
+
+} // namespace gui
+
+} // namespace sealtk
+
+#endif

--- a/sealtk/gui/CMakeLists.txt
+++ b/sealtk/gui/CMakeLists.txt
@@ -6,6 +6,8 @@ include(SEALTKUtils)
 
 sealtk_add_library(sealtk::gui
   SOURCES
+    AbstractItemModel.cpp
+    AbstractItemRepresentation.cpp
     Player.cpp
     PlayerControl.cpp
     Resources.cpp
@@ -14,6 +16,8 @@ sealtk_add_library(sealtk::gui
     resources/Resources.qrc
 
   HEADERS
+    AbstractItemModel.hpp
+    AbstractItemRepresentation.hpp
     Player.hpp
     PlayerControl.hpp
     Resources.hpp
@@ -24,3 +28,5 @@ sealtk_add_library(sealtk::gui
 
   EXPORT_HEADER Export.h
   )
+
+add_subdirectory(test)

--- a/sealtk/gui/test/AbstractItemRepresentation.cpp
+++ b/sealtk/gui/test/AbstractItemRepresentation.cpp
@@ -1,0 +1,259 @@
+/* This file is part of SEAL-TK, and is distributed under the OSI-approved BSD
+ * 3-Clause License. See top-level LICENSE file or
+ * https://github.com/Kitware/seal-tk/blob/master/LICENSE for details. */
+
+#include <sealtk/gui/AbstractItemModel.hpp>
+#include <sealtk/gui/AbstractItemRepresentation.hpp>
+
+#include <sealtk/core/DataModelTypes.hpp>
+
+#include <vital/types/timestamp.h>
+
+#include <vital/range/iota.h>
+
+#include <QUuid>
+#include <QtTest>
+
+namespace kv = kwiver::vital;
+namespace kvr = kwiver::vital::range;
+
+namespace sealtk
+{
+
+namespace gui
+{
+
+namespace test
+{
+
+namespace // anonymous
+{
+
+constexpr int ROW_COUNT = 3;
+constexpr int COLUMN_COUNT = 3;
+
+QString const nameData[ROW_COUNT] = {
+  QStringLiteral("Pig"),
+  QStringLiteral("Cow"),
+  QStringLiteral("Emu"),
+};
+
+QUuid const uniqueIdentityData[ROW_COUNT] = {
+  {0xe98b70d3, 0x3daf, 0x48de, 0x91, 0x2b, 0x1b, 0xe1, 0x11, 0xf6, 0x61, 0x89},
+  {0xede5f114, 0x0333, 0x4c5f, 0x96, 0x59, 0x52, 0x50, 0xef, 0x24, 0xfe, 0x0d},
+  {0x478d0854, 0x9d2e, 0x478a, 0xb8, 0x82, 0x47, 0x56, 0x13, 0xfa, 0xe4, 0x53},
+};
+
+kv::timestamp::time_t const timeData[ROW_COUNT] = {
+  545415827289077l,
+  1381481842745356l,
+  1559840855588146l,
+};
+
+bool const visibilityData[ROW_COUNT] = {
+  true,
+  true,
+  false,
+};
+
+// ============================================================================
+class TestModel : public AbstractItemModel
+{
+public:
+  TestModel(QObject* parent) : AbstractItemModel{parent} {}
+
+  int rowCount(QModelIndex const& parent) const override;
+  QVariant data(QModelIndex const& index, int role) const override;
+};
+
+// ----------------------------------------------------------------------------
+int TestModel::rowCount(QModelIndex const& parent) const
+{
+  return (parent.isValid() ? 0 : ROW_COUNT);
+}
+
+// ----------------------------------------------------------------------------
+QVariant TestModel::data(QModelIndex const& index, int role) const
+{
+  auto const r = index.row();
+  if (!index.isValid() || r < 0 || r >= ROW_COUNT)
+  {
+    return {};
+  }
+
+  switch (role)
+  {
+    case core::NameRole:
+      return nameData[r];
+
+    case core::UniqueIdentityRole:
+      return uniqueIdentityData[r];
+
+    case core::StartTimeRole:
+    case core::EndTimeRole:
+      return static_cast<qint64>(timeData[r]);
+
+    case core::UserVisibilityRole:
+      return visibilityData[r];
+
+    default:
+      return AbstractItemModel::data(index, role);
+  }
+}
+
+// ============================================================================
+class TestRepresentation : public AbstractItemRepresentation
+{
+public:
+  TestRepresentation(QObject* parent);
+};
+
+// ----------------------------------------------------------------------------
+TestRepresentation::TestRepresentation(QObject* parent)
+  : AbstractItemRepresentation{parent}
+{
+  this->setColumnRoles({
+    core::NameRole,
+    core::UniqueIdentityRole,
+    core::StartTimeRole,
+  });
+}
+
+} // namespace <anonymous>
+
+// ============================================================================
+class TestAbstractItemRepresentation : public QObject
+{
+  Q_OBJECT
+
+private slots:
+  void initTestCase();
+  void modelAttributes();
+  void displayData();
+  void displayData_data();
+  void tooltipData();
+  void tooltipData_data();
+
+private:
+  QAbstractItemModel* model;
+  AbstractItemRepresentation* representation;
+
+  void testData(int role);
+};
+
+// ----------------------------------------------------------------------------
+void TestAbstractItemRepresentation::initTestCase()
+{
+  this->model = new TestModel{this};
+  this->representation = new TestRepresentation{this};
+  this->representation->setSourceModel(this->model);
+}
+
+// ----------------------------------------------------------------------------
+void TestAbstractItemRepresentation::modelAttributes()
+{
+  // Test with visibility::shadow
+  this->representation->setItemVisibilityMode(ShadowHidden);
+  QCOMPARE(this->representation->rowCount(), ROW_COUNT);
+  QCOMPARE(this->representation->columnCount(), COLUMN_COUNT);
+
+  // Test with visibility::omit
+  this->representation->setItemVisibilityMode(OmitHidden);
+  QCOMPARE(this->representation->rowCount(), ROW_COUNT - 1);
+  QCOMPARE(this->representation->columnCount(), COLUMN_COUNT);
+}
+
+// ----------------------------------------------------------------------------
+void TestAbstractItemRepresentation::displayData()
+{
+  testData(Qt::DisplayRole);
+}
+
+// ----------------------------------------------------------------------------
+void TestAbstractItemRepresentation::displayData_data()
+{
+  QTest::addColumn<int>("row");
+  QTest::addColumn<ItemVisibilityMode>("mode");
+  QTest::addColumn<QStringList>("expected");
+
+  QTest::newRow("row 0") << 0 << ShadowHidden << QStringList{
+    QStringLiteral("Pig"),
+    QStringLiteral("{e98b70d3-3daf-48de-912b-1be111f66189}"),
+    QStringLiteral("16:23:47.289"),
+  };
+  QTest::newRow("row 1") << 1 << ShadowHidden << QStringList{
+    QStringLiteral("Cow"),
+    QStringLiteral("{ede5f114-0333-4c5f-9659-5250ef24fe0d}"),
+    QStringLiteral("08:57:22.745"),
+  };
+  QTest::newRow("row 2 (shadow)") << 2 << ShadowHidden << QStringList{
+    QStringLiteral("Emu"),
+    QStringLiteral("{478d0854-9d2e-478a-b882-475613fae453}"),
+    QStringLiteral("17:07:35.588"),
+  };
+  QTest::newRow("row 2 (omit)") << 2 << OmitHidden << QStringList{};
+}
+
+// ----------------------------------------------------------------------------
+void TestAbstractItemRepresentation::tooltipData()
+{
+  testData(Qt::ToolTipRole);
+}
+
+// ----------------------------------------------------------------------------
+void TestAbstractItemRepresentation::tooltipData_data()
+{
+  QTest::addColumn<int>("row");
+  QTest::addColumn<ItemVisibilityMode>("mode");
+  QTest::addColumn<QStringList>("expected");
+
+  QTest::newRow("row 0") << 0 << ShadowHidden << QStringList{
+    QStringLiteral("Pig"),
+    QStringLiteral("{e98b70d3-3daf-48de-912b-1be111f66189}"),
+    QStringLiteral("1987-04-14 16:23:47.289"),
+  };
+  QTest::newRow("row 1") << 1 << ShadowHidden << QStringList{
+    QStringLiteral("Cow"),
+    QStringLiteral("{ede5f114-0333-4c5f-9659-5250ef24fe0d}"),
+    QStringLiteral("2013-10-11 08:57:22.745"),
+  };
+  QTest::newRow("row 2 (shadow)") << 2 << ShadowHidden << QStringList{
+    QStringLiteral("Emu"),
+    QStringLiteral("{478d0854-9d2e-478a-b882-475613fae453}"),
+    QStringLiteral("2019-06-06 17:07:35.588"),
+  };
+  QTest::newRow("row 2 (omit)") << 2 << OmitHidden << QStringList{};
+}
+
+// ----------------------------------------------------------------------------
+void TestAbstractItemRepresentation::testData(int role)
+{
+  QFETCH(int, row);
+  QFETCH(ItemVisibilityMode, mode);
+  QFETCH(QStringList, expected);
+
+  this->representation->setItemVisibilityMode(mode);
+
+  if (expected.isEmpty())
+  {
+    QVERIFY(row >= this->representation->rowCount());
+  }
+  else
+  {
+    for (auto const i : kvr::iota(expected.size()))
+    {
+      auto const& index = this->representation->index(row, i);
+      auto const& data = this->representation->data(index, role);
+      QCOMPARE(data.toString(), expected[i]);
+    }
+  }
+}
+
+} // namespace test
+
+} // namespace gui
+
+} // namespace sealtk
+
+QTEST_MAIN(sealtk::gui::test::TestAbstractItemRepresentation)
+#include "AbstractItemRepresentation.moc"

--- a/sealtk/gui/test/CMakeLists.txt
+++ b/sealtk/gui/test/CMakeLists.txt
@@ -1,0 +1,14 @@
+# This file is part of SEAL-TK, and is distributed under the OSI-approved BSD
+# 3-Clause License. See top-level LICENSE file or
+# https://github.com/Kitware/seal-tk/blob/master/LICENSE for details.
+
+include(SEALTKUtils)
+
+sealtk_add_test(AbstractItemRepresentation
+  SOURCES
+    AbstractItemRepresentation.cpp
+
+  PRIVATE_LINK_LIBRARIES
+    sealtk::gui
+    sealtk::core
+  )

--- a/utilities/source_check.py
+++ b/utilities/source_check.py
@@ -58,6 +58,13 @@ class SourceFile:
                 self._contents = f.read()
         return self._contents
 
+    def is_trivial_cpp(self):
+        c = self.contents().strip().split('\n')
+        if len(c) == 1 and c[0].startswith('//'):
+            return True
+        else:
+            return False
+
     def is_cpp_source(self):
         return filename_components(self.filename)[0] == "sealtk" and \
             matches(self.filename, r"\.cpp$")
@@ -103,7 +110,8 @@ class SourceFile:
 
     def test_copyright(self):
         if self.is_cpp_source() or self.is_cpp_header():
-            assert matches(self.contents(), copyright_notice_cpp_re)
+            if not self.is_trivial_cpp():
+                assert matches(self.contents(), copyright_notice_cpp_re)
         elif self.is_cmake():
             assert matches(self.contents(), copyright_notice_cmake_re)
         elif self.is_python():


### PR DESCRIPTION
Add base classes for item data models, and representations of item data. The latter is more or less imported wholesale from [ViViA](https://github.com/kitware/vivia), while the former adds some minor convenience features. The representation class defines a mechanism by which the underlying model can provide data in a representation-agnostic manner, and serves as a base class for implementing representations.

Also, tweak `source_check.py` to skip the copyright check on "trivial" C++ sources (defined as a file consisting of a single comment). This avoids adding a mostly-gratuitous copyright notice to `DataModelTypes.cpp`, which exists only to trigger CMake's automoc, and whose entire contents consists of a comment explaining this.