### PR TITLE
Fix duplicate Q_NAMESPACE issue

### DIFF
--- a/sealtk/gui/AbstractItemRepresentation.hpp
+++ b/sealtk/gui/AbstractItemRepresentation.hpp
@@ -6,6 +6,7 @@
 #define sealtk_gui_AbstractItemRepresentation_hpp
 
 #include <sealtk/gui/Export.h>
+#include <sealtk/gui/Enums.hpp>
 
 #include <qtGlobal.h>
 
@@ -16,22 +17,6 @@ namespace sealtk
 
 namespace gui
 {
-
-Q_NAMESPACE
-
-/// Item visibility mode.
-///
-/// This enumeration specifies how "hidden" items will be manipulated by the
-/// representation.
-enum ItemVisibilityMode
-{
-  /// "Hidden" items are not shown.
-  OmitHidden,
-  /// "Hidden" items are shown in an alternate ("grayed out") color.
-  ShadowHidden,
-};
-
-Q_ENUM_NS(ItemVisibilityMode)
 
 class AbstractItemRepresentationPrivate;
 

--- a/sealtk/gui/CMakeLists.txt
+++ b/sealtk/gui/CMakeLists.txt
@@ -8,6 +8,7 @@ sealtk_add_library(sealtk::gui
   SOURCES
     AbstractItemModel.cpp
     AbstractItemRepresentation.cpp
+    Enums.cpp
     Player.cpp
     PlayerControl.cpp
     Resources.cpp
@@ -18,6 +19,7 @@ sealtk_add_library(sealtk::gui
   HEADERS
     AbstractItemModel.hpp
     AbstractItemRepresentation.hpp
+    Enums.hpp
     Player.hpp
     PlayerControl.hpp
     Resources.hpp

--- a/sealtk/gui/Enums.cpp
+++ b/sealtk/gui/Enums.cpp
@@ -1,0 +1,1 @@
+// This file exists solely to trigger automoc for the corresponding header

--- a/sealtk/gui/Enums.hpp
+++ b/sealtk/gui/Enums.hpp
@@ -1,0 +1,44 @@
+/* This file is part of SEAL-TK, and is distributed under the OSI-approved BSD
+ * 3-Clause License. See top-level LICENSE file or
+ * https://github.com/Kitware/seal-tk/blob/master/LICENSE for details. */
+
+#ifndef sealtk_gui_Enums_hpp
+#define sealtk_gui_Enums_hpp
+
+#include <QObject>
+
+namespace sealtk
+{
+
+namespace gui
+{
+
+Q_NAMESPACE
+
+/// Item visibility mode.
+///
+/// This enumeration specifies how "hidden" items will be manipulated by the
+/// representation.
+enum ItemVisibilityMode
+{
+  /// "Hidden" items are not shown.
+  OmitHidden,
+  /// "Hidden" items are shown in an alternate ("grayed out") color.
+  ShadowHidden,
+};
+
+Q_ENUM_NS(ItemVisibilityMode)
+
+enum class ContrastMode
+{
+  Manual,
+  Percentile,
+};
+
+Q_ENUM_NS(ContrastMode)
+
+} // namespace gui
+
+} // namespace sealtk
+
+#endif

--- a/sealtk/gui/Player.hpp
+++ b/sealtk/gui/Player.hpp
@@ -6,6 +6,7 @@
 #define sealtk_gui_Player_hpp
 
 #include <sealtk/gui/Export.h>
+#include <sealtk/gui/Enums.hpp>
 
 #include <sealtk/core/VideoDistributor.hpp>
 
@@ -24,16 +25,6 @@ namespace sealtk
 
 namespace gui
 {
-
-Q_NAMESPACE
-
-enum class ContrastMode
-{
-  Manual,
-  Percentile,
-};
-
-Q_ENUM_NS(ContrastMode)
 
 class PlayerPrivate;
 


### PR DESCRIPTION
Having two instances of Q_NAMESPACE causes issues with Qt, so move
all enums into one file.