### PR TITLE
Fix crash when changing video source

### DIFF
--- a/sealtk/gui/Player.cpp
+++ b/sealtk/gui/Player.cpp
@@ -248,6 +248,9 @@ void Player::setVideoSource(core::VideoDistributor* videoSource)
 
     if (d->videoSource)
     {
+      connect(videoSource, &QObject::destroyed, this,
+              [this]{ this->setVideoSource(nullptr); });
+
       connect(videoSource, &core::VideoDistributor::frameReady, this,
               [this](core::VideoFrame const& frame){
                 this->setImage(frame.image, frame.metaData);


### PR DESCRIPTION
Modify `gui::Player` to disassociate itself from its video source when the source is destroyed. I suspect this has been broken, but wasn't noticed because a) the application only ever destroys a video source when replacing it with a new one, and b) prior to the new video API, the old source was only destroyed after assigning the new source to the `Player`. When the new API was introduced (#21), the application logic also changed to destroy the old source first, which would leave the `Player` with a dangling reference.

This should fix #27.