### PR TITLE
Reset computed levels when video source changes

### DIFF
--- a/sealtk/gui/Player.cpp
+++ b/sealtk/gui/Player.cpp
@@ -245,6 +245,8 @@ void Player::setVideoSource(core::VideoDistributor* videoSource)
     }
 
     d->videoSource = videoSource;
+    d->percentileLevels.clear();
+    ++d->percentileCookie;
 
     if (d->videoSource)
     {


### PR DESCRIPTION
Modify `gui::Player` to reset any computed percentile levels (and also change the cookie, so any pending computations will be ignored) when the video source changes. This fixes incorrectly carrying over previously computed levels to different images that happen to have the same time stamps.

This should fix #30.