### PR TITLE
Fix ImageUtils test on GCC 4.8

### DIFF
--- a/sealtk/core/test/ImageUtils.cpp
+++ b/sealtk/core/test/ImageUtils.cpp
@@ -39,6 +39,15 @@ namespace // anonymous
 constexpr size_t IMAGE_SIZE = 64;
 constexpr auto FBO_SIZE = static_cast<int>(IMAGE_SIZE);
 
+#if __GNUC__ == 4 && __GNUC_MINOR__ == 8
+// GCC 4.8 chokes on raw string literals passed as arguments to a macro (i.e.
+// the immediately following code). Work around this by instead using the
+// QString-from-literal constructors. This is less efficient, but at least it
+// compiles.
+#undef QStringLiteral
+#define QStringLiteral QString
+#endif
+
 static auto const VERTEX_SHADER_CODE = QStringLiteral(R"(
   #version 130
 
@@ -81,13 +90,13 @@ static auto const PLANE_PACKED_FRAGMENT_SHADER_CODE = QStringLiteral(R"(
   })");
 
 // ----------------------------------------------------------------------------
-size_t operator ""_z(unsigned long long x)
+constexpr size_t operator"" _z(unsigned long long x)
 {
   return static_cast<size_t>(x);
 }
 
 // ----------------------------------------------------------------------------
-ptrdiff_t operator ""_t(unsigned long long x)
+constexpr ptrdiff_t operator"" _t(unsigned long long x)
 {
   return static_cast<ptrdiff_t>(x);
 }


### PR DESCRIPTION
GCC 4.8 chokes on raw string literals passed as arguments to a macro, which are used by the aforementioned unit test. Work around this by redefining `QStringLiteral` → `QString` when using GCC 4.8, which results in constructing a `QString` using the string literal constructor (`QString(char const*)`) instead. This is less efficient, but at least it compiles.

GCC 4.8 also insists on an unnecessary space between the quotes and suffix of a user-defined literal operator. (Clang 3.1 does also, but later compilers don't require it. It seems this was an early restriction in UDL definitions that was subsequently relaxed.)

(While we're at it, also make the UDL's `constexpr`; they really ought to be...)