### PR TITLE
Explicitly require Qt ≥ 5.10

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,7 @@ list(APPEND CMAKE_MODULE_PATH
   "${PROJECT_SOURCE_DIR}/cmake/thirdparty"
   )
 
-find_package(Qt5 REQUIRED COMPONENTS
+find_package(Qt5 5.10 REQUIRED COMPONENTS
   Test
   Widgets
   Xml


### PR DESCRIPTION
Modify finding Qt to explicitly require Qt ≥ 5.10. We actually require this already, due to use of features added in 5.10; this just arranges to get an explicit version-mismatch error at configure time rather than less obvious build errors.