### PR TITLE
Add "detections" (track) list to GUI

### DIFF
--- a/sealtk/gui/CMakeLists.txt
+++ b/sealtk/gui/CMakeLists.txt
@@ -8,6 +8,7 @@ sealtk_add_library(sealtk::gui
   SOURCES
     AbstractItemRepresentation.cpp
     Enums.cpp
+    FusionModel.cpp
     Player.cpp
     PlayerControl.cpp
     Resources.cpp
@@ -18,6 +19,7 @@ sealtk_add_library(sealtk::gui
   HEADERS
     AbstractItemRepresentation.hpp
     Enums.hpp
+    FusionModel.hpp
     Player.hpp
     PlayerControl.hpp
     Resources.hpp

--- a/sealtk/gui/FusionModel.cpp
+++ b/sealtk/gui/FusionModel.cpp
@@ -1,0 +1,276 @@
+/* This file is part of SEAL-TK, and is distributed under the OSI-approved BSD
+ * 3-Clause License. See top-level LICENSE file or
+ * https://github.com/Kitware/seal-tk/blob/master/LICENSE for details. */
+
+#include <sealtk/gui/FusionModel.hpp>
+
+#include <sealtk/core/DataModelTypes.hpp>
+
+#include <vital/types/timestamp.h>
+
+#include <vital/range/indirect.h>
+#include <vital/range/iota.h>
+
+#include <qtGet.h>
+
+#include <QDebug>
+
+namespace kv = kwiver::vital;
+namespace kvr = kwiver::vital::range;
+
+namespace sealtk
+{
+
+namespace gui
+{
+
+namespace // anonymous
+{
+
+// ============================================================================
+struct RowData
+{
+  qint64 id;
+  QMultiHash<QAbstractItemModel*, int> rows;
+};
+
+// ----------------------------------------------------------------------------
+struct MinTime
+{
+  using data_t = kv::timestamp::time_t;
+
+  inline static data_t fuse(data_t a, data_t b)
+  {
+    return std::min(a, b);
+  }
+};
+
+// ----------------------------------------------------------------------------
+struct MaxTime
+{
+  using data_t = kv::timestamp::time_t;
+
+  inline static data_t fuse(data_t a, data_t b)
+  {
+    return std::max(a, b);
+  }
+};
+
+// ----------------------------------------------------------------------------
+struct BooleanOr
+{
+  using data_t = bool;
+
+  inline static data_t fuse(data_t a, data_t b)
+  {
+    return a || b;
+  }
+};
+
+} // namespace <anonymous>
+
+// ============================================================================
+class FusionModelPrivate
+{
+public:
+  QSet<QAbstractItemModel*> models;
+  QHash<qint64, int> items;
+  QVector<RowData> data;
+
+  void addModelData(QAbstractItemModel* model);
+  void removeModelData(QAbstractItemModel* model);
+
+  template <typename Fusor>
+
+  static QVariant fuseData(RowData const& rowData, int role);
+};
+
+// ----------------------------------------------------------------------------
+QTE_IMPLEMENT_D_FUNC(FusionModel)
+
+// ----------------------------------------------------------------------------
+FusionModel::FusionModel(QObject* parent)
+  : AbstractItemModel{parent}, d_ptr{new FusionModelPrivate}
+{
+}
+
+// ----------------------------------------------------------------------------
+FusionModel::~FusionModel()
+{
+}
+
+// ----------------------------------------------------------------------------
+int FusionModel::rowCount(QModelIndex const& parent) const
+{
+  QTE_D();
+
+  if (parent.isValid())
+  {
+    return 0;
+  }
+
+  return d->data.size();
+}
+
+// ----------------------------------------------------------------------------
+QVariant FusionModel::data(QModelIndex const& index, int role) const
+{
+  if (this->checkIndex(index, IndexIsValid | ParentIsInvalid))
+  {
+    QTE_D();
+
+    auto const& r = d->data[index.row()];
+    switch (role)
+    {
+      case core::NameRole:
+      case core::LogicalIdentityRole:
+        return r.id;
+
+      case core::StartTimeRole:
+        return d->fuseData<MinTime>(r, role);
+
+      case core::EndTimeRole:
+        return d->fuseData<MaxTime>(r, role);
+
+      case core::UserVisibilityRole:
+        return d->fuseData<BooleanOr>(r, role);
+
+      default:
+        break;
+    }
+  }
+
+  return AbstractItemModel::data(index, role);
+}
+
+// ----------------------------------------------------------------------------
+void FusionModel::addModel(QAbstractItemModel* model)
+{
+  QTE_D();
+
+  if (!d->models.contains(model))
+  {
+    this->beginResetModel();
+    d->models.insert(model);
+    d->addModelData(model);
+    this->endResetModel();
+
+    connect(model, &QObject::destroyed, this,
+            [model, this]{ this->removeModel(model); });
+    // TODO handle rows added, removed, moved
+  }
+}
+
+// ----------------------------------------------------------------------------
+void FusionModel::removeModel(QAbstractItemModel* model)
+{
+  QTE_D();
+
+  if (d->models.contains(model))
+  {
+    this->beginResetModel();
+    d->models.remove(model);
+    d->removeModelData(model);
+    this->endResetModel();
+  }
+}
+
+// ----------------------------------------------------------------------------
+void FusionModelPrivate::addModelData(QAbstractItemModel* model)
+{
+  // Examine all rows of model
+  for (auto const sourceRow : kvr::iota(model->rowCount()))
+  {
+    auto const& index = model->index(sourceRow, 0);
+    auto const iid =
+      model->data(index, core::LogicalIdentityRole).toLongLong();
+
+    // Find our row for this item (if any)
+    auto const localRow = this->items.value(iid, -1);
+    if (localRow < 0)
+    {
+      // Item is new
+      auto r = RowData{iid, {{model, sourceRow}}};
+      this->items.insert(iid, this->data.size());
+      this->data.append(std::move(r));
+    }
+    else
+    {
+      // Update source rows of existing item
+      auto& r = this->data[localRow];
+      r.rows.insert(model, sourceRow);
+    }
+  }
+}
+
+// ----------------------------------------------------------------------------
+void FusionModelPrivate::removeModelData(QAbstractItemModel* model)
+{
+  auto i = this->data.begin();
+  auto rows = this->data.size();
+  auto row = decltype(rows){0};
+
+  while (row < rows)
+  {
+    // Remove model rows
+    i->rows.remove(model);
+
+    // Check if item still has any associated source rows
+    if (!i->rows.isEmpty())
+    {
+      // It does; move on to the next
+      ++i;
+      ++row;
+    }
+    else
+    {
+      // Item has no more source rows; remove it
+      this->items.remove(i->id);
+
+      if (row == --rows)
+      {
+        this->data.erase(i);
+        break; // This was the last item, so we must be done
+      }
+      else
+      {
+        // Replace with last item and update map
+        *i = this->data.takeLast();
+        this->items[i->id] = row;
+      }
+    }
+  }
+}
+
+// ----------------------------------------------------------------------------
+template <typename Fusor>
+QVariant FusionModelPrivate::fuseData(RowData const& rowData, int role)
+{
+  using data_t = typename Fusor::data_t;
+
+  auto first = true;
+  auto result = data_t{};
+
+  for (auto const& sourceRow : rowData.rows | kvr::indirect)
+  {
+    auto* const model = sourceRow.key();
+    auto const& index = model->index(sourceRow.value(), 0);
+    auto const data = model->data(index, role).value<data_t>();
+
+    if (first)
+    {
+      result = data;
+      first = false;
+    }
+    else
+    {
+      result = Fusor::fuse(result, data);
+    }
+  }
+
+  return QVariant::fromValue(result);
+}
+
+} // namespace gui
+
+} // namespace sealtk

--- a/sealtk/gui/FusionModel.hpp
+++ b/sealtk/gui/FusionModel.hpp
@@ -1,0 +1,49 @@
+/* This file is part of SEAL-TK, and is distributed under the OSI-approved BSD
+ * 3-Clause License. See top-level LICENSE file or
+ * https://github.com/Kitware/seal-tk/blob/master/LICENSE for details. */
+
+#ifndef sealtk_gui_FusionModel_hpp
+#define sealtk_gui_FusionModel_hpp
+
+#include <sealtk/gui/Export.h>
+
+#include <sealtk/core/AbstractItemModel.hpp>
+
+#include <qtGlobal.h>
+
+namespace sealtk
+{
+
+namespace gui
+{
+
+class FusionModelPrivate;
+
+class SEALTK_GUI_EXPORT FusionModel : public sealtk::core::AbstractItemModel
+{
+  Q_OBJECT
+
+public:
+  FusionModel(QObject* parent = nullptr);
+  ~FusionModel();
+
+  // Reimplemented from QAbstractItemModel
+  int rowCount(QModelIndex const& parent = {}) const override;
+  QVariant data(QModelIndex const& index, int role) const override;
+
+public slots:
+  void addModel(QAbstractItemModel*);
+  void removeModel(QAbstractItemModel*);
+
+protected:
+  QTE_DECLARE_PRIVATE_PTR(FusionModel);
+
+private:
+  QTE_DECLARE_PRIVATE(FusionModel);
+};
+
+} // namespace gui
+
+} // namespace sealtk
+
+#endif

--- a/sealtk/gui/test/CMakeLists.txt
+++ b/sealtk/gui/test/CMakeLists.txt
@@ -12,3 +12,12 @@ sealtk_add_test(AbstractItemRepresentation
     sealtk::gui
     sealtk::core
   )
+
+sealtk_add_test(FusionModel
+  SOURCES
+    FusionModel.cpp
+
+  PRIVATE_LINK_LIBRARIES
+    sealtk::gui
+    sealtk::core
+  )

--- a/sealtk/gui/test/FusionModel.cpp
+++ b/sealtk/gui/test/FusionModel.cpp
@@ -1,0 +1,215 @@
+/* This file is part of SEAL-TK, and is distributed under the OSI-approved BSD
+ * 3-Clause License. See top-level LICENSE file or
+ * https://github.com/Kitware/seal-tk/blob/master/LICENSE for details. */
+
+#include <sealtk/gui/FusionModel.hpp>
+
+#include <sealtk/core/AbstractItemModel.hpp>
+#include <sealtk/core/DataModelTypes.hpp>
+
+#include <vital/types/timestamp.h>
+
+#include <vital/range/iota.h>
+
+#include <QVector>
+
+#include <QtTest>
+
+namespace kvr = kwiver::vital::range;
+
+using time_us_t = kwiver::vital::timestamp::time_t;
+
+namespace sealtk
+{
+
+namespace gui
+{
+
+namespace test
+{
+
+namespace // anonymous
+{
+
+// ============================================================================
+struct DataRow
+{
+  qint64 id;
+  time_us_t start;
+  time_us_t end;
+  bool visible;
+};
+
+// ----------------------------------------------------------------------------
+constexpr DataRow data1[] = {
+  {1, 50, 50, true},
+  {2, 10, 80, true},
+  {3, 70, 80, false},
+};
+
+// ----------------------------------------------------------------------------
+constexpr DataRow data2[] = {
+  {2, 50, 60, false},
+  {3, 70, 90, true},
+  {4, 40, 50, false},
+};
+
+// ----------------------------------------------------------------------------
+constexpr DataRow data3[] = {
+  {2, 40, 50, true},
+  {4, 30, 80, false},
+  {5, 20, 70, false},
+};
+
+// ============================================================================
+class TestModel : public sealtk::core::AbstractItemModel
+{
+public:
+  template <size_t N>
+  TestModel(DataRow const (&rows)[N])
+    : rowData{rows}, size{static_cast<int>(N)} {}
+
+  int rowCount(QModelIndex const& parent = {}) const override
+  { return (parent.isValid() ? 0 : this->size); }
+
+  QVariant data(QModelIndex const& index, int role) const override;
+
+private:
+  DataRow const* const rowData;
+  int const size;
+};
+
+// ----------------------------------------------------------------------------
+QVariant TestModel::data(QModelIndex const& index, int role) const
+{
+  if (this->checkIndex(index, IndexIsValid | ParentIsInvalid))
+  {
+    auto& row = this->rowData[index.row()];
+    switch (role)
+    {
+      case sealtk::core::NameRole:
+      case sealtk::core::LogicalIdentityRole:
+        return row.id;
+
+      case sealtk::core::StartTimeRole:
+        return QVariant::fromValue(row.start);
+
+      case sealtk::core::EndTimeRole:
+        return QVariant::fromValue(row.end);
+
+      case sealtk::core::UserVisibilityRole:
+        return row.visible;
+
+      default:
+        break;
+    }
+  }
+
+  return sealtk::core::AbstractItemModel::data(index, role);
+}
+
+// ----------------------------------------------------------------------------
+void testRow(
+  QAbstractItemModel const& model, int row,
+  time_us_t expectedStart, time_us_t expectedEnd, bool expectedVisibility)
+{
+  using sealtk::core::LogicalIdentityRole;
+  using sealtk::core::StartTimeRole;
+  using sealtk::core::EndTimeRole;
+  using sealtk::core::VisibilityRole;
+
+  auto const& index = model.index(row, 0);
+
+  QVERIFY(model.data(index, StartTimeRole).canConvert<time_us_t>());
+  QCOMPARE(model.data(model.index(row, 0), StartTimeRole).value<time_us_t>(),
+           expectedStart);
+
+  QVERIFY(model.data(index, EndTimeRole).canConvert<time_us_t>());
+  QCOMPARE(model.data(model.index(row, 0), EndTimeRole).value<time_us_t>(),
+           expectedEnd);
+
+  QVERIFY(model.data(index, VisibilityRole).canConvert<bool>());
+  QCOMPARE(model.data(model.index(row, 0), VisibilityRole).toBool(),
+           expectedVisibility);
+}
+
+// ----------------------------------------------------------------------------
+void testModelData(
+  QAbstractItemModel const& model, qint64 id,
+  time_us_t expectedStart, time_us_t expectedEnd, bool expectedVisibility)
+{
+  using sealtk::core::LogicalIdentityRole;
+
+  for (auto const row : kvr::iota(model.rowCount()))
+  {
+    auto const& index = model.index(row, 0);
+
+    QVERIFY(model.data(index, LogicalIdentityRole).canConvert<qint64>());
+    if (model.data(index, LogicalIdentityRole).value<qint64>() == id)
+    {
+      testRow(model, row, expectedStart, expectedEnd, expectedVisibility);
+      return;
+    }
+  }
+
+  QFAIL(qPrintable(QStringLiteral("Did not find id %1 in model").arg(id)));
+}
+
+} // namespace <anonymous>
+
+// ============================================================================
+class TestFusionModel : public QObject
+{
+  Q_OBJECT
+
+private slots:
+  void operations();
+};
+
+// ----------------------------------------------------------------------------
+void TestFusionModel::operations()
+{
+  TestModel dm1{data1};
+  TestModel dm2{data2};
+  TestModel dm3{data3};
+
+  // Test model shape
+  FusionModel fm;
+  QCOMPARE(fm.rowCount(), 0);
+
+  fm.addModel(&dm1);
+  QCOMPARE(fm.rowCount(), 3);
+
+  fm.addModel(&dm2);
+  QCOMPARE(fm.rowCount(), 4);
+
+  fm.addModel(&dm3);
+  QCOMPARE(fm.rowCount(), 5);
+
+  // Test model data
+  testModelData(fm, 1, 50, 50, true);
+  testModelData(fm, 2, 10, 80, true);
+  testModelData(fm, 3, 70, 90, true);
+  testModelData(fm, 4, 30, 80, false);
+  testModelData(fm, 5, 20, 70, false);
+
+  // Remove a model
+  fm.removeModel(&dm1);
+
+  // Test model shape and data again
+  QCOMPARE(fm.rowCount(), 4);
+  testModelData(fm, 2, 40, 60, true);
+  testModelData(fm, 3, 70, 90, true);
+  testModelData(fm, 4, 30, 80, false);
+  testModelData(fm, 5, 20, 70, false);
+}
+
+} // namespace test
+
+} // namespace gui
+
+} // namespace sealtk
+
+// ----------------------------------------------------------------------------
+QTEST_MAIN(sealtk::gui::test::TestFusionModel)
+#include "FusionModel.moc"

--- a/sealtk/noaa/Main.cpp
+++ b/sealtk/noaa/Main.cpp
@@ -2,19 +2,22 @@
  * 3-Clause License. See top-level LICENSE file or
  * https://github.com/Kitware/seal-tk/blob/master/LICENSE for details. */
 
-#include <QApplication>
-#include <QCommandLineParser>
-#include <QDir>
-
 #include <sealtk/noaa/gui/Window.hpp>
 
 #include <sealtk/noaa/core/Config.h>
 
-#include <sealtk/core/Version.h>
-
 #include <sealtk/gui/Resources.hpp>
 
+#include <sealtk/core/AbstractDataSource.hpp>
+#include <sealtk/core/Version.h>
+
 #include <vital/plugin_loader/plugin_manager.h>
+
+#include <QApplication>
+#include <QCommandLineParser>
+#include <QDir>
+
+#include <memory>
 
 //-----------------------------------------------------------------------------
 int main(int argc, char** argv)
@@ -56,6 +59,8 @@ int main(int argc, char** argv)
   }
 
   kwiver::vital::plugin_manager::instance().load_all_plugins();
+
+  qRegisterMetaType<std::shared_ptr<QAbstractItemModel>>();
 
   sealtk::noaa::gui::Window window;
   window.setPipelineDirectory(pipelineDirectory);

--- a/sealtk/noaa/gui/Player.cpp
+++ b/sealtk/noaa/gui/Player.cpp
@@ -71,17 +71,6 @@ Player::Player(Role role, QWidget* parent)
 
   connect(d->loadDetectionsAction, &QAction::triggered,
           this, &Player::loadDetectionsTriggered);
-
-  /* TODO
-  connect(this, &sealtk::gui::Player::videoSourceChanged, this,
-          [d](sealtk::core::VideoSource* videoSource){
-            d->loadDetectionsAction->setEnabled(
-              videoSource &&
-              qobject_cast<sealtk::core::KwiverVideoSource*>(videoSource));
-          });
-  */
-
-  d->loadDetectionsAction->setEnabled(false);
 }
 
 // ----------------------------------------------------------------------------

--- a/sealtk/noaa/gui/Window.cpp
+++ b/sealtk/noaa/gui/Window.cpp
@@ -172,6 +172,17 @@ Window::Window(QWidget* parent)
           this, [d]{
             d->videoController->nextFrame(0);
           });
+  connect(d->ui.tracks, &QAbstractItemView::doubleClicked,
+          this, [d](QModelIndex const& index){
+            auto const& t =
+              d->trackModel.data(d->trackRepresentation.mapToSource(index),
+                                 sc::StartTimeRole);
+            if (t.isValid())
+            {
+              d->ui.control->setTime(
+                t.value<kwiver::vital::timestamp::time_t>());
+            }
+          });
 
   d->registerVideoSourceFactory(
     "Image List File...",

--- a/sealtk/noaa/gui/Window.cpp
+++ b/sealtk/noaa/gui/Window.cpp
@@ -10,6 +10,10 @@
 
 #include <sealtk/noaa/core/ImageListVideoSourceFactory.hpp>
 
+#include <sealtk/gui/AbstractItemRepresentation.hpp>
+#include <sealtk/gui/FusionModel.hpp>
+
+#include <sealtk/core/DataModelTypes.hpp>
 #include <sealtk/core/DirectoryListing.hpp>
 #include <sealtk/core/FileVideoSourceFactory.hpp>
 #include <sealtk/core/KwiverPipelineWorker.hpp>
@@ -37,6 +41,9 @@
 
 #include <memory>
 
+namespace sc = sealtk::core;
+namespace sg = sealtk::gui;
+
 namespace sealtk
 {
 
@@ -46,8 +53,8 @@ namespace noaa
 namespace gui
 {
 
-namespace sc = sealtk::core;
-namespace sg = sealtk::gui;
+namespace // anonymous
+{
 
 //=============================================================================
 struct WindowData
@@ -55,7 +62,42 @@ struct WindowData
   sc::VideoSource* videoSource = nullptr;
   sg::SplitterWindow* window = nullptr;
   sealtk::noaa::gui::Player* player = nullptr;
+
+  std::shared_ptr<sc::AbstractDataSource> trackSource;
+  std::shared_ptr<QAbstractItemModel> trackModel;
 };
+
+//=============================================================================
+class TrackRepresentation : public sg::AbstractItemRepresentation
+{
+public:
+  TrackRepresentation()
+  {
+    this->setColumnRoles({sc::NameRole, sc::StartTimeRole});
+  }
+
+  QVariant headerData(int section, Qt::Orientation orientation,
+                      int role = Qt::DisplayRole) const override
+  {
+    if (orientation == Qt::Horizontal && role == Qt::DisplayRole &&
+        section >= 0 && section < this->columnCount())
+    {
+      switch (this->roleForColumn(section))
+      {
+        case sc::StartTimeRole:
+        case sc::EndTimeRole:
+          return QStringLiteral("Time");
+        default:
+          break;
+      }
+    }
+
+    return this->AbstractItemRepresentation::headerData(
+      section, orientation, role);
+  }
+};
+
+} // namespace <anonymous>
 
 //=============================================================================
 class WindowPrivate
@@ -69,14 +111,15 @@ public:
   void createWindow(WindowData* data, QString const& title,
                     sealtk::noaa::gui::Player::Role role);
 
-  void loadDetections();
+  void loadDetections(WindowData* data);
   void executePipeline(QString const& pipelineFile);
 
   Ui::Window ui;
 
+  sg::FusionModel trackModel;
+  TrackRepresentation trackRepresentation;
+
   std::unique_ptr<sc::VideoController> videoController;
-  std::shared_ptr<sc::AbstractDataSource> trackSource;
-  std::shared_ptr<QAbstractItemModel> trackModel;
 
   WindowData eoWindow;
   WindowData irWindow;
@@ -99,6 +142,9 @@ Window::Window(QWidget* parent)
 {
   QTE_D();
   d->ui.setupUi(this);
+
+  d->trackRepresentation.setSourceModel(&d->trackModel);
+  d->ui.tracks->setModel(&d->trackRepresentation);
 
   constexpr auto Master = sealtk::noaa::gui::Player::Role::Master;
   constexpr auto Slave = sealtk::noaa::gui::Player::Role::Slave;
@@ -291,13 +337,13 @@ void WindowPrivate::createWindow(WindowData* data, QString const& title,
 
   QObject::connect(
     data->player, &sealtk::noaa::gui::Player::loadDetectionsTriggered,
-    q, [this]{ this->loadDetections(); });
+    q, [data, this]{ this->loadDetections(data); });
 
   this->ui.centralwidget->addWidget(data->window);
 }
 
 //-----------------------------------------------------------------------------
-void WindowPrivate::loadDetections()
+void WindowPrivate::loadDetections(WindowData* data)
 {
   QTE_Q();
 
@@ -310,17 +356,17 @@ void WindowPrivate::loadDetections()
     params.addQueryItem("input:type", "kw18");
     uri.setQuery(params);
 
-    this->trackSource =
+    data->trackSource =
       std::make_shared<sc::KwiverTrackSource>(q);
 
     QObject::connect(
-      this->trackSource.get(), &sc::AbstractDataSource::modelReady, q,
-      [this](std::shared_ptr<QAbstractItemModel> const& model){
-        this->trackModel = model;
-        // TODO
+      data->trackSource.get(), &sc::AbstractDataSource::modelReady, q,
+      [data, this](std::shared_ptr<QAbstractItemModel> const& model){
+        data->trackModel = model;
+        this->trackModel.addModel(model.get());
       });
     QObject::connect(
-      this->trackSource.get(), &sc::AbstractDataSource::failed, q,
+      data->trackSource.get(), &sc::AbstractDataSource::failed, q,
       [q](QString const& message){
         QMessageBox mb{q};
         mb.setIcon(QMessageBox::Warning);
@@ -331,7 +377,7 @@ void WindowPrivate::loadDetections()
         mb.exec();
       });
 
-    this->trackSource->readData(uri);
+    data->trackSource->readData(uri);
   }
 }
 

--- a/sealtk/noaa/gui/Window.ui
+++ b/sealtk/noaa/gui/Window.ui
@@ -63,6 +63,21 @@
    <addaction name="menuTools"/>
    <addaction name="menuHelp"/>
   </widget>
+  <widget class="QDockWidget" name="trackDock">
+   <property name="windowTitle">
+    <string>Detections</string>
+   </property>
+   <attribute name="dockWidgetArea">
+    <number>8</number>
+   </attribute>
+   <widget class="QWidget" name="trackDockContents">
+    <layout class="QVBoxLayout" name="verticalLayout_2">
+     <item>
+      <widget class="QTreeView" name="tracks"/>
+     </item>
+    </layout>
+   </widget>
+  </widget>
   <action name="actionAbout">
    <property name="text">
     <string>&amp;About...</string>


### PR DESCRIPTION
Update NOAA GUI to use new `KwiverTrackSource`. Create `FusionModel`. Use this to implement a "detections"¹ list to the NOAA GUI.

(¹ As far as implementation, this is actually a *track* list, but NOAA only deals with tracks consisting of a single detection, and we use "detections" in the UI.)