### PR TITLE
(Re)implement track rendering

### DIFF
--- a/sealtk/core/AbstractItemModel.cpp
+++ b/sealtk/core/AbstractItemModel.cpp
@@ -45,16 +45,25 @@ QModelIndex AbstractItemModel::parent(QModelIndex const& child) const
 // ----------------------------------------------------------------------------
 QVariant AbstractItemModel::data(QModelIndex const& index, int role) const
 {
-  if (role == core::VisibilityRole)
+  switch (role)
   {
-    // VisibilityRole is meant to be defined by filters based on whatever
-    // filtering criteria they are using. Models notionally should not provide
-    // this role directly. However, this will break if a model is used without
-    // a filter, so by default, map VisibilityRole to UserVisibilityRole.
-    return this->data(index, core::UserVisibilityRole);
-  }
+    case VisibilityRole:
+      // VisibilityRole is meant to be defined by filters based on whatever
+      // filtering criteria they are using. Models notionally should not
+      // provide this role directly. However, that would break things if a
+      // model is used without a filter, so by default, map VisibilityRole to
+      // UserVisibilityRole.
+      return this->data(index, UserVisibilityRole);
 
-  return {};
+    case UserVisibilityRole:
+      // Subclasses ought to implement this, but since our framework is
+      // absolutely dependent on this producing a sensible value, provide a
+      // fallback just in case.
+      return true;
+
+    default:
+      return {};
+  }
 }
 
 } // namespace core

--- a/sealtk/core/AbstractProxyModel.cpp
+++ b/sealtk/core/AbstractProxyModel.cpp
@@ -1,0 +1,61 @@
+/* This file is part of SEAL-TK, and is distributed under the OSI-approved BSD
+ * 3-Clause License. See top-level LICENSE file or
+ * https://github.com/Kitware/seal-tk/blob/master/LICENSE for details. */
+
+#include <sealtk/core/AbstractProxyModel.hpp>
+
+#include <sealtk/core/DataModelTypes.hpp>
+
+#include <vital/types/timestamp.h>
+
+namespace kv = kwiver::vital;
+
+namespace sealtk
+{
+
+namespace core
+{
+
+// ----------------------------------------------------------------------------
+bool AbstractProxyModel::lessThan(
+  QVariant const& left, QVariant const& right, int role) const
+{
+  switch (role)
+  {
+    // String comparisons
+    case core::NameRole:
+    case core::UniqueIdentityRole:
+      return QString::localeAwareCompare(left.toString(),
+                                         right.toString());
+
+    // Boolean comparisons
+    case core::VisibilityRole:
+    case core::UserVisibilityRole:
+      return left.toBool() < right.toBool();
+
+    // Integer comparisons
+    // TODO classification
+    case core::ItemTypeRole:
+      return left.toInt() < right.toInt();
+
+    // Floating-point comparisons
+    // TODO confidence
+    //   return left.toDouble() < right.toDouble();
+
+    // Timestamp comparisons
+    case core::StartTimeRole:
+    case core::EndTimeRole:
+    {
+      auto const lt = left.value<kv::timestamp::time_t>();
+      auto const rt = right.value<kv::timestamp::time_t>();
+      return lt < rt;
+    }
+
+    default:
+      return false;
+  }
+}
+
+} // namespace core
+
+} // namespace sealtk

--- a/sealtk/core/AbstractProxyModel.cpp
+++ b/sealtk/core/AbstractProxyModel.cpp
@@ -17,6 +17,39 @@ namespace core
 {
 
 // ----------------------------------------------------------------------------
+bool AbstractProxyModel::isValidData(QVariant const& data, int role)
+{
+  switch (role)
+  {
+    // String comparisons
+    case core::NameRole:
+    case core::UniqueIdentityRole:
+      return data.canConvert<QString>();
+
+    // Boolean comparisons
+    case core::VisibilityRole:
+    case core::UserVisibilityRole:
+      return data.canConvert<bool>();
+
+    // Integer comparisons
+    // TODO classification
+    case core::ItemTypeRole:
+      return data.canConvert<int>();
+
+    // Floating-point comparisons
+    // TODO confidence
+    //   return data.canConvert<double>();
+
+    case core::StartTimeRole:
+    case core::EndTimeRole:
+      return data.canConvert<kv::timestamp::time_t>();
+
+    default:
+      return false;
+  }
+}
+
+// ----------------------------------------------------------------------------
 bool AbstractProxyModel::lessThan(
   QVariant const& left, QVariant const& right, int role) const
 {

--- a/sealtk/core/AbstractProxyModel.hpp
+++ b/sealtk/core/AbstractProxyModel.hpp
@@ -1,0 +1,50 @@
+/* This file is part of SEAL-TK, and is distributed under the OSI-approved BSD
+ * 3-Clause License. See top-level LICENSE file or
+ * https://github.com/Kitware/seal-tk/blob/master/LICENSE for details. */
+
+#ifndef sealtk_core_AbstractProxyModel_hpp
+#define sealtk_core_AbstractProxyModel_hpp
+
+#include <sealtk/core/Export.h>
+
+#include <qtGlobal.h>
+
+#include <QSortFilterProxyModel>
+
+namespace sealtk
+{
+
+namespace core
+{
+
+/// Base class for proxy models.
+///
+/// This class provides a base class for implementing sort/filter proxy models.
+/// In particular, it provides a shared mechanism for comparing data that is
+/// data-role aware.
+class SEALTK_CORE_EXPORT AbstractProxyModel : public QSortFilterProxyModel
+{
+  Q_OBJECT
+
+public:
+  using QSortFilterProxyModel::QSortFilterProxyModel;
+
+protected:
+  /// Compare data.
+  ///
+  /// This method performs a comparison of two data items which have the type
+  /// \p role. If \p role is not a supported data role, the result is \c false.
+  ///
+  /// \return \c true if the left data is less than the right data; otherwise
+  ///         \c false.
+  virtual bool lessThan(
+    QVariant const& left, QVariant const& right, int role) const;
+
+  using QSortFilterProxyModel::lessThan;
+};
+
+} // namespace core
+
+} // namespace sealtk
+
+#endif

--- a/sealtk/core/AbstractProxyModel.hpp
+++ b/sealtk/core/AbstractProxyModel.hpp
@@ -30,6 +30,12 @@ public:
   using QSortFilterProxyModel::QSortFilterProxyModel;
 
 protected:
+  /// Test if data is valid.
+  ///
+  /// This method tests if a data value is valid (i.e. is convertible to the
+  /// appropriate type) for a given data role.
+  static bool isValidData(QVariant const& data, int role);
+
   /// Compare data.
   ///
   /// This method performs a comparison of two data items which have the type

--- a/sealtk/core/CMakeLists.txt
+++ b/sealtk/core/CMakeLists.txt
@@ -25,6 +25,7 @@ sealtk_add_library(sealtk::core
     KwiverPipelineWorker.cpp
     KwiverTrackSource.cpp
     KwiverVideoSource.cpp
+    ScalarFilterModel.cpp
     TimeStamp.cpp
     VideoController.cpp
     VideoDistributor.cpp
@@ -49,6 +50,7 @@ sealtk_add_library(sealtk::core
     KwiverPipelineWorker.hpp
     KwiverTrackSource.hpp
     KwiverVideoSource.hpp
+    ScalarFilterModel.hpp
     TimeMap.hpp
     TimeStamp.hpp
     UnsharedPointer.hpp

--- a/sealtk/core/CMakeLists.txt
+++ b/sealtk/core/CMakeLists.txt
@@ -13,6 +13,7 @@ sealtk_add_library(sealtk::core
   SOURCES
     AbstractDataSource.cpp
     AbstractItemModel.cpp
+    AbstractProxyModel.cpp
     AutoLevelsTask.cpp
     DataModelTypes.cpp
     DateUtils.cpp
@@ -36,6 +37,7 @@ sealtk_add_library(sealtk::core
   HEADERS
     AbstractDataSource.hpp
     AbstractItemModel.hpp
+    AbstractProxyModel.hpp
     AutoLevelsTask.hpp
     DataModelTypes.hpp
     DateUtils.hpp

--- a/sealtk/core/DataModelTypes.hpp
+++ b/sealtk/core/DataModelTypes.hpp
@@ -73,6 +73,16 @@ enum ItemDataRole
   /// (timestamp::time_t) Scene time at which the item leaves scope.
   EndTimeRole,
 
+  /// (QRectF) Image area location of an entity.
+  ///
+  /// This provides the area location (i.e. an axis-aligned bounding box) of an
+  /// item. The coordinates are in the image space of the imagery corresponding
+  /// to the item's time. (This datum is normally only available for items
+  /// which have a specific, distinct time point, i.e. which have the same
+  /// value for both StartTimeRole and EndTimeRole. Such items are often
+  /// children of higher-level items.)
+  AreaLocationRole,
+
   /// First role that can be used for model-specific purposes.
   UserRole = Qt::UserRole + 224
 };

--- a/sealtk/core/KwiverTrackModel.cpp
+++ b/sealtk/core/KwiverTrackModel.cpp
@@ -15,6 +15,8 @@
 
 #include <qtScopedValueChange.h>
 
+#include <QRectF>
+
 namespace kv = kwiver::vital;
 namespace kvr = kwiver::vital::range;
 
@@ -113,53 +115,119 @@ int KwiverTrackModel::rowCount(QModelIndex const& parent) const
 
   if (parent.isValid())
   {
-    // TODO detections?
-    return 0;
+    QTE_D();
+
+    auto const pr = parent.row();
+    if (pr < 0 || pr >= static_cast<int>(d->tracks.size()))
+    {
+      return 0;
+    }
+
+    auto const pru = static_cast<uint>(pr);
+    return static_cast<int>(d->tracks[pru].track->size());
   }
 
   return static_cast<int>(d->tracks.size());
 }
 
 // ----------------------------------------------------------------------------
+QModelIndex KwiverTrackModel::index(
+  int row, int column, QModelIndex const& parent) const
+{
+  if (parent.isValid())
+  {
+    auto const data = static_cast<uint>(parent.row() + 1);
+    return this->createIndex(row, column, data);
+  }
+
+  return this->createIndex(row, column);
+}
+
+// ----------------------------------------------------------------------------
+QModelIndex KwiverTrackModel::parent(QModelIndex const& child) const
+{
+  if (auto const r = child.internalId())
+  {
+    return this->createIndex(static_cast<int>(r - 1), 0);
+  }
+  return {};
+}
+
+// ----------------------------------------------------------------------------
 QVariant KwiverTrackModel::data(QModelIndex const& index, int role) const
 {
-  // TODO detections?
-  if (this->checkIndex(index, IndexIsValid | ParentIsInvalid))
+  if (this->checkIndex(index, IndexIsValid))
   {
     QTE_D_SHARED();
 
-    auto const& track = d->tracks[static_cast<unsigned>(index.row())];
-    switch (role)
+    if (auto const pr = static_cast<int>(index.internalId()))
     {
-      case core::NameRole:
-      case core::LogicalIdentityRole:
-        return static_cast<qint64>(track.track->id());
+      auto const& track = d->tracks[static_cast<uint>(pr - 1)];
+      auto const& state =
+        std::static_pointer_cast<kv::object_track_state>(
+          *(track.track->begin() + index.row()));
 
-      case core::StartTimeRole:
-        if (!track.track->empty())
-        {
-          auto const& s =
-            std::static_pointer_cast<kv::object_track_state>(
-              track.track->front());
-          return QVariant::fromValue(s->time());
-        }
-        return {};
+      switch (role)
+      {
+        case core::NameRole:
+        case core::LogicalIdentityRole:
+          return static_cast<qint64>(track.track->id());
 
-      case core::EndTimeRole:
-        if (!track.track->empty())
-        {
-          auto const& s =
-            std::static_pointer_cast<kv::object_track_state>(
-              track.track->back());
-          return QVariant::fromValue(s->time());
-        }
-        return {};
+        case core::StartTimeRole:
+        case core::EndTimeRole:
+          return QVariant::fromValue(state->time());
 
-      case core::UserVisibilityRole:
-        return track.visible;
+        case AreaLocationRole:
+          if (state->detection)
+          {
+            auto const& bb = state->detection->bounding_box();
+            return QRectF{bb.min_x(), bb.min_y(), bb.width(), bb.height()};
+          }
+          return {};
 
-      default:
-        break;
+        case core::UserVisibilityRole:
+          return track.visible;
+
+        default:
+          break;
+      }
+    }
+    else
+    {
+      auto const& track = d->tracks[static_cast<uint>(index.row())];
+
+      switch (role)
+      {
+        case core::NameRole:
+        case core::LogicalIdentityRole:
+          return static_cast<qint64>(track.track->id());
+
+        case core::StartTimeRole:
+          if (!track.track->empty())
+          {
+            auto const& s =
+              std::static_pointer_cast<kv::object_track_state>(
+                track.track->front());
+            return QVariant::fromValue(s->time());
+          }
+          return {};
+
+        case core::EndTimeRole:
+          if (!track.track->empty())
+          {
+            auto const& s =
+              std::static_pointer_cast<kv::object_track_state>(
+                track.track->back());
+            return QVariant::fromValue(s->time());
+          }
+          return {};
+
+        case core::UserVisibilityRole:
+          return track.visible;
+
+        default:
+          break;
+      }
     }
   }
 

--- a/sealtk/core/KwiverTrackModel.cpp
+++ b/sealtk/core/KwiverTrackModel.cpp
@@ -231,7 +231,7 @@ QVariant KwiverTrackModel::data(QModelIndex const& index, int role) const
     }
   }
 
-  return AbstractItemModel::data(index, role);
+  return this->AbstractItemModel::data(index, role);
 }
 
 // ----------------------------------------------------------------------------

--- a/sealtk/core/KwiverTrackModel.hpp
+++ b/sealtk/core/KwiverTrackModel.hpp
@@ -32,6 +32,9 @@ public:
   // Reimplemented from QAbstractItemModel
   int rowCount(QModelIndex const& parent = {}) const override;
   QVariant data(QModelIndex const& index, int role) const override;
+  QModelIndex parent(QModelIndex const& child) const override;
+  QModelIndex index(
+    int row, int column, QModelIndex const& parent) const override;
 
 public slots:
   void clear();

--- a/sealtk/core/ScalarFilterModel.cpp
+++ b/sealtk/core/ScalarFilterModel.cpp
@@ -183,7 +183,7 @@ QVariant ScalarFilterModel::data(QModelIndex const& index, int role) const
     }
   }
 
-  return AbstractProxyModel::data(index, role);
+  return this->AbstractProxyModel::data(index, role);
 }
 
 } // namespace core

--- a/sealtk/core/ScalarFilterModel.cpp
+++ b/sealtk/core/ScalarFilterModel.cpp
@@ -1,0 +1,191 @@
+/* This file is part of SEAL-TK, and is distributed under the OSI-approved BSD
+ * 3-Clause License. See top-level LICENSE file or
+ * https://github.com/Kitware/seal-tk/blob/master/LICENSE for details. */
+
+#include <sealtk/core/ScalarFilterModel.hpp>
+
+#include <sealtk/core/DataModelTypes.hpp>
+
+#include <vital/range/indirect.h>
+
+#include <QHash>
+
+namespace kvr = kwiver::vital::range;
+
+namespace sealtk
+{
+
+namespace core
+{
+
+// ============================================================================
+class ScalarFilterModelPrivate
+{
+public:
+  QHash<int, QPair<QVariant, QVariant>> bounds;
+};
+
+// ----------------------------------------------------------------------------
+QTE_IMPLEMENT_D_FUNC(ScalarFilterModel)
+
+// ----------------------------------------------------------------------------
+ScalarFilterModel::ScalarFilterModel(QObject* parent)
+  : AbstractProxyModel{parent}, d_ptr{new ScalarFilterModelPrivate}
+{
+  // Our filtering is dependent on the logical data model's data; therefore, we
+  // need to re-filter and/or re-sort when the underlying data changes, and so
+  // we enable doing so by default
+  this->setDynamicSortFilter(true);
+}
+
+// ----------------------------------------------------------------------------
+ScalarFilterModel::~ScalarFilterModel()
+{
+}
+
+// ----------------------------------------------------------------------------
+void ScalarFilterModel::setLowerBound(int role, QVariant const& bound)
+{
+  if (this->isValidData(bound, role))
+  {
+    QTE_D();
+
+    auto& old = d->bounds[role];
+    if (bound != old.first)
+    {
+      old.first = bound;
+      this->invalidate();
+    }
+  }
+}
+
+// ----------------------------------------------------------------------------
+void ScalarFilterModel::setUpperBound(int role, QVariant const& bound)
+{
+  if (this->isValidData(bound, role))
+  {
+    QTE_D();
+
+    auto& old = d->bounds[role];
+    if (bound != old.second)
+    {
+      old.second = bound;
+      this->invalidate();
+    }
+  }
+}
+
+// ----------------------------------------------------------------------------
+void ScalarFilterModel::setBound(
+  int role, QVariant const& lower, QVariant const& upper)
+{
+  if (this->isValidData(lower, role) && this->isValidData(upper, role))
+  {
+    QTE_D();
+
+    auto& old = d->bounds[role];
+    if (lower != old.first || upper != old.second)
+    {
+      old.first = lower;
+      old.second = upper;
+      this->invalidate();
+    }
+  }
+}
+
+// ----------------------------------------------------------------------------
+void ScalarFilterModel::clearLowerBound(int role)
+{
+  QTE_D();
+
+  auto const& i = d->bounds.find(role);
+  if (i != d->bounds.end() && i->first.isValid())
+  {
+    if (i->second.isValid())
+    {
+      i->first.clear();
+    }
+    else
+    {
+      d->bounds.erase(i);
+    }
+
+    this->invalidate();
+  }
+}
+
+// ----------------------------------------------------------------------------
+void ScalarFilterModel::clearUpperBound(int role)
+{
+  QTE_D();
+
+  auto const& i = d->bounds.find(role);
+  if (i != d->bounds.end() && i->second.isValid())
+  {
+    if (i->first.isValid())
+    {
+      i->second.clear();
+    }
+    else
+    {
+      d->bounds.erase(i);
+    }
+
+    this->invalidate();
+  }
+}
+
+// ----------------------------------------------------------------------------
+void ScalarFilterModel::clearBound(int role)
+{
+  QTE_D();
+
+  if (d->bounds.remove(role))
+  {
+    this->invalidate();
+  }
+}
+
+// ----------------------------------------------------------------------------
+void ScalarFilterModel::clearBounds()
+{
+  QTE_D();
+
+  if (!d->bounds.isEmpty())
+  {
+    d->bounds.clear();
+    this->invalidate();
+  }
+}
+
+// ----------------------------------------------------------------------------
+QVariant ScalarFilterModel::data(QModelIndex const& index, int role) const
+{
+  if (role == VisibilityRole)
+  {
+    QTE_D();
+
+    auto* const sm = this->sourceModel();
+    auto const& si = this->mapToSource(index);
+
+    for (auto const& i : d->bounds | kvr::indirect)
+    {
+      auto const role = i.key();
+      auto const& sd = sm->data(si, role);
+      if (i->first.isValid() && this->lessThan(sd, i->first, role))
+      {
+        return false;
+      }
+      if (i->second.isValid() && this->lessThan(i->second, sd, role))
+      {
+        return false;
+      }
+    }
+  }
+
+  return AbstractProxyModel::data(index, role);
+}
+
+} // namespace core
+
+} // namespace sealtk

--- a/sealtk/core/ScalarFilterModel.hpp
+++ b/sealtk/core/ScalarFilterModel.hpp
@@ -1,0 +1,59 @@
+/* This file is part of SEAL-TK, and is distributed under the OSI-approved BSD
+ * 3-Clause License. See top-level LICENSE file or
+ * https://github.com/Kitware/seal-tk/blob/master/LICENSE for details. */
+
+#ifndef sealtk_core_ScalarFilterModel_hpp
+#define sealtk_core_ScalarFilterModel_hpp
+
+#include <sealtk/core/AbstractProxyModel.hpp>
+
+#include <qtGlobal.h>
+
+namespace sealtk
+{
+
+namespace core
+{
+
+class ScalarFilterModelPrivate;
+
+/// Generic high/low-pass filter for scalar data.
+///
+/// This class provides simple filtering of a data model based on high- or
+/// low-pass filters applied to scalar data. Any number of such filters may be
+/// configured.
+///
+/// Note that, unlike a "normal" filter, this does \em not actually reject
+/// rows, but rather modifies the VisibilityRole data of the underlying model.
+class SEALTK_CORE_EXPORT ScalarFilterModel : public AbstractProxyModel
+{
+  Q_OBJECT
+
+public:
+  explicit ScalarFilterModel(QObject* parent = nullptr);
+  ~ScalarFilterModel() override;
+
+  QVariant data(QModelIndex const& index, int role) const override;
+
+public slots:
+  void setLowerBound(int role, QVariant const& bound);
+  void setUpperBound(int role, QVariant const& bound);
+  void setBound(int role, QVariant const& lower, QVariant const& upper);
+
+  void clearLowerBound(int role);
+  void clearUpperBound(int role);
+  void clearBound(int role);
+  void clearBounds();
+
+protected:
+  QTE_DECLARE_PRIVATE_PTR(ScalarFilterModel)
+
+private:
+  QTE_DECLARE_PRIVATE(ScalarFilterModel)
+};
+
+} // namespace core
+
+} // namespace sealtk
+
+#endif

--- a/sealtk/core/test/CMakeLists.txt
+++ b/sealtk/core/test/CMakeLists.txt
@@ -99,6 +99,14 @@ sealtk_add_test(DirectoryListing
     sealtk::core
   )
 
+sealtk_add_test(ScalarFilterModel
+  SOURCES
+    ScalarFilterModel.cpp
+
+  PRIVATE_LINK_LIBRARIES
+    sealtk::core
+  )
+
 sealtk_add_test(TimeMap
   SOURCES
     TimeMap.cpp

--- a/sealtk/core/test/ScalarFilterModel.cpp
+++ b/sealtk/core/test/ScalarFilterModel.cpp
@@ -1,0 +1,206 @@
+/* This file is part of SEAL-TK, and is distributed under the OSI-approved BSD
+ * 3-Clause License. See top-level LICENSE file or
+ * https://github.com/Kitware/seal-tk/blob/master/LICENSE for details. */
+
+#include <sealtk/core/ScalarFilterModel.hpp>
+
+#include <sealtk/core/AbstractItemModel.hpp>
+#include <sealtk/core/DataModelTypes.hpp>
+
+#include <vital/types/timestamp.h>
+
+#include <vital/range/iota.h>
+
+#include <QSet>
+
+#include <QtTest>
+
+namespace kvr = kwiver::vital::range;
+
+using time_us_t = kwiver::vital::timestamp::time_t;
+
+namespace QTest
+{
+
+// ----------------------------------------------------------------------------
+template<> char* toString<QSet<int>>(QSet<int> const& set)
+{
+  QString s;
+
+  QDebug d{&s};
+  d << set;
+
+  return qstrdup(qPrintable(s));
+}
+
+} // namespace QTest
+
+namespace sealtk
+{
+
+namespace core
+{
+
+namespace test
+{
+
+namespace // anonymous
+{
+
+// ============================================================================
+class TestModel : public sealtk::core::AbstractItemModel
+{
+public:
+  TestModel(int rows) : rows{rows} {}
+
+  int rowCount(QModelIndex const& parent = {}) const override
+  { return (parent.isValid() ? 0 : this->rows); }
+
+  QVariant data(QModelIndex const& index, int role) const override;
+
+private:
+  int const rows;
+};
+
+// ----------------------------------------------------------------------------
+QVariant TestModel::data(QModelIndex const& index, int role) const
+{
+  if (this->checkIndex(index, IndexIsValid | ParentIsInvalid))
+  {
+    auto const row = index.row();
+    switch (role)
+    {
+      case sealtk::core::NameRole:
+      case sealtk::core::LogicalIdentityRole:
+        return row;
+
+      case sealtk::core::StartTimeRole:
+      case sealtk::core::EndTimeRole:
+        return QVariant::fromValue(static_cast<time_us_t>(row * 100));
+
+      default:
+        break;
+    }
+  }
+
+  return sealtk::core::AbstractItemModel::data(index, role);
+}
+
+// ----------------------------------------------------------------------------
+QSet<int> visibleRows(QAbstractItemModel const& model)
+{
+  using sealtk::core::VisibilityRole;
+
+  auto result = QSet<int>{};
+  for (auto const row : kvr::iota(model.rowCount()))
+  {
+    auto const& index = model.index(row, 0);
+
+    [&]{ QVERIFY(model.data(index, VisibilityRole).canConvert<bool>()); }();
+    if (model.data(model.index(row, 0), VisibilityRole).toBool())
+    {
+      result.insert(row);
+    }
+  }
+
+  return result;
+}
+
+} // namespace <anonymous>
+
+// ============================================================================
+class TestScalarFilterModel : public QObject
+{
+  Q_OBJECT
+
+private slots:
+  void filtering();
+  void filtering_data();
+};
+
+// ----------------------------------------------------------------------------
+void TestScalarFilterModel::filtering()
+{
+  using sealtk::core::StartTimeRole;
+  using sealtk::core::EndTimeRole;
+
+  QFETCH(int, rows);
+  QFETCH(QVariant, startLowerBound);
+  QFETCH(QVariant, startUpperBound);
+  QFETCH(QVariant, endLowerBound);
+  QFETCH(QVariant, endUpperBound);
+  QFETCH(QSet<int>, expected);
+
+  TestModel model{rows};
+  ScalarFilterModel filter;
+
+  filter.setSourceModel(&model);
+  if (startLowerBound.isValid())
+  {
+    filter.setLowerBound(StartTimeRole, startLowerBound);
+  }
+  if (startUpperBound.isValid())
+  {
+    filter.setUpperBound(StartTimeRole, startUpperBound);
+  }
+  if (endLowerBound.isValid())
+  {
+    filter.setLowerBound(EndTimeRole, endLowerBound);
+  }
+  if (endUpperBound.isValid())
+  {
+    filter.setUpperBound(EndTimeRole, endUpperBound);
+  }
+
+  QCOMPARE(visibleRows(filter), expected);
+}
+
+// ----------------------------------------------------------------------------
+void TestScalarFilterModel::filtering_data()
+{
+  QTest::addColumn<int>("rows");
+  QTest::addColumn<QVariant>("startLowerBound");
+  QTest::addColumn<QVariant>("startUpperBound");
+  QTest::addColumn<QVariant>("endLowerBound");
+  QTest::addColumn<QVariant>("endUpperBound");
+  QTest::addColumn<QSet<int>>("expected");
+
+  QTest::newRow("single lower") << 10
+    << QVariant::fromValue(300) << QVariant{}
+    << QVariant{} << QVariant{}
+    << QSet<int>{3, 4, 5, 6, 7, 8, 9};
+  QTest::newRow("single upper") << 10
+    << QVariant{} << QVariant::fromValue(700)
+    << QVariant{} << QVariant{}
+    << QSet<int>{0, 1, 2, 3, 4, 5, 6, 7};
+  QTest::newRow("single (lower + upper)") << 10
+    << QVariant::fromValue(300) << QVariant::fromValue(700)
+    << QVariant{} << QVariant{}
+    << QSet<int>{3, 4, 5, 6, 7};
+  QTest::newRow("multiple lower") << 10
+    << QVariant::fromValue(200) << QVariant{}
+    << QVariant::fromValue(400) << QVariant{}
+    << QSet<int>{4, 5, 6, 7, 8, 9};
+  QTest::newRow("multiple upper") << 10
+    << QVariant{} << QVariant::fromValue(600)
+    << QVariant{} << QVariant::fromValue(800)
+    << QSet<int>{0, 1, 2, 3, 4, 5, 6};
+  QTest::newRow("(single lower) + (single upper)") << 10
+    << QVariant::fromValue(300) << QVariant{}
+    << QVariant{} << QVariant::fromValue(700)
+    << QSet<int>{3, 4, 5, 6, 7};
+  QTest::newRow("(multiple lower) + (multiple upper)") << 10
+    << QVariant::fromValue(400) << QVariant::fromValue(800)
+    << QVariant::fromValue(200) << QVariant::fromValue(600)
+    << QSet<int>{4, 5, 6};
+}
+
+} // namespace test
+
+} // namespace core
+
+} // namespace sealtk
+
+// ----------------------------------------------------------------------------
+QTEST_MAIN(sealtk::core::test::TestScalarFilterModel)
+#include "ScalarFilterModel.moc"

--- a/sealtk/core/test/ScalarFilterModel.cpp
+++ b/sealtk/core/test/ScalarFilterModel.cpp
@@ -83,7 +83,7 @@ QVariant TestModel::data(QModelIndex const& index, int role) const
     }
   }
 
-  return sealtk::core::AbstractItemModel::data(index, role);
+  return this->sealtk::core::AbstractItemModel::data(index, role);
 }
 
 // ----------------------------------------------------------------------------

--- a/sealtk/core/test/TestTracks.hpp
+++ b/sealtk/core/test/TestTracks.hpp
@@ -12,6 +12,7 @@
 #include <QRectF>
 
 class QAbstractItemModel;
+class QModelIndex;
 
 namespace sealtk
 {
@@ -31,6 +32,12 @@ void testTrackData(
   QAbstractItemModel const& model, int row,
   kwiver::vital::track_id_t id,
   TimeMap<QRectF> const& boxes);
+
+void testTrackData(
+  QAbstractItemModel const& model,
+  QModelIndex const& parent,
+  kwiver::vital::timestamp::time_t time,
+  QRectF const& box);
 
 namespace data
 {

--- a/sealtk/gui/AbstractItemRepresentation.cpp
+++ b/sealtk/gui/AbstractItemRepresentation.cpp
@@ -19,6 +19,8 @@ namespace sealtk
 namespace gui
 {
 
+using sealtk::core::AbstractProxyModel;
+
 // ============================================================================
 class AbstractItemRepresentationPrivate
 {
@@ -34,7 +36,7 @@ QTE_IMPLEMENT_D_FUNC(AbstractItemRepresentation)
 
 // ----------------------------------------------------------------------------
 AbstractItemRepresentation::AbstractItemRepresentation(QObject* parent)
-  : QSortFilterProxyModel{parent}, d_ptr{new AbstractItemRepresentationPrivate}
+  : AbstractProxyModel{parent}, d_ptr{new AbstractItemRepresentationPrivate}
 {
   // Our filtering (and likely that of our subclasses) is dependent on the
   // logical data model's data; therefore, we need to re-filter and/or re-sort
@@ -131,7 +133,7 @@ QVariant AbstractItemRepresentation::data(
     }
   }
 
-  return QSortFilterProxyModel::data(index, role);
+  return AbstractProxyModel::data(index, role);
 }
 
 // ----------------------------------------------------------------------------
@@ -247,7 +249,7 @@ QVariant AbstractItemRepresentation::headerData(
     }
   }
 
-  return QSortFilterProxyModel::headerData(section, orientation, role);
+  return AbstractProxyModel::headerData(section, orientation, role);
 }
 
 // ----------------------------------------------------------------------------
@@ -266,7 +268,7 @@ bool AbstractItemRepresentation::lessThan(
     return this->lessThan(left, right, dataRole);
   }
 
-  return QSortFilterProxyModel::lessThan(left, right);
+  return AbstractProxyModel::lessThan(left, right);
 }
 
 // ----------------------------------------------------------------------------
@@ -281,43 +283,7 @@ bool AbstractItemRepresentation::lessThan(
   Q_ASSERT(left.column() == right.column());
 
   auto* const sm = this->sourceModel();
-  auto const& leftData = sm->data(left, role);
-  auto const& rightData = sm->data(right, role);
-
-  switch (role)
-  {
-    // String comparisons
-    case core::NameRole:
-    case core::UniqueIdentityRole:
-      return QString::localeAwareCompare(leftData.toString(),
-                                         rightData.toString());
-
-    // Boolean comparisons
-    case core::VisibilityRole:
-    case core::UserVisibilityRole:
-      return leftData.toBool() < rightData.toBool();
-
-    // Integer comparisons
-    // TODO classification
-    case core::ItemTypeRole:
-      return leftData.toInt() < rightData.toInt();
-
-    // Floating-point comparisons
-    // TODO confidence
-    //   return leftData.toDouble() < rightData.toDouble();
-
-    // Timestamp comparisons
-    case core::StartTimeRole:
-    case core::EndTimeRole:
-    {
-      auto const lt = leftData.value<kv::timestamp::time_t>();
-      auto const rt = rightData.value<kv::timestamp::time_t>();
-      return lt < rt;
-    }
-
-    default:
-      return false;
-  }
+  return this->lessThan(sm->data(left, role), sm->data(right, role), role);
 }
 
 // ----------------------------------------------------------------------------
@@ -337,7 +303,7 @@ bool AbstractItemRepresentation::filterAcceptsRow(
     }
   }
 
-  return QSortFilterProxyModel::filterAcceptsRow(sourceRow, sourceParent);
+  return AbstractProxyModel::filterAcceptsRow(sourceRow, sourceParent);
 }
 
 // ----------------------------------------------------------------------------
@@ -356,7 +322,7 @@ bool AbstractItemRepresentation::filterAcceptsColumn(
     return false;
   }
 
-  return QSortFilterProxyModel::filterAcceptsColumn(
+  return AbstractProxyModel::filterAcceptsColumn(
     sourceColumn, sourceParent);
 }
 
@@ -365,7 +331,7 @@ void AbstractItemRepresentation::sort(int column, Qt::SortOrder order)
 {
   QTE_D();
 
-  QSortFilterProxyModel::sort(column, order);
+  AbstractProxyModel::sort(column, order);
 
   // Determine, if we are sorting (column >= 0), if QSortFilterProxyModel
   // figured out what column to sort; if not, we may need to force a sort later

--- a/sealtk/gui/AbstractItemRepresentation.cpp
+++ b/sealtk/gui/AbstractItemRepresentation.cpp
@@ -133,7 +133,7 @@ QVariant AbstractItemRepresentation::data(
     }
   }
 
-  return AbstractProxyModel::data(index, role);
+  return this->AbstractProxyModel::data(index, role);
 }
 
 // ----------------------------------------------------------------------------
@@ -249,7 +249,7 @@ QVariant AbstractItemRepresentation::headerData(
     }
   }
 
-  return AbstractProxyModel::headerData(section, orientation, role);
+  return this->AbstractProxyModel::headerData(section, orientation, role);
 }
 
 // ----------------------------------------------------------------------------
@@ -268,7 +268,7 @@ bool AbstractItemRepresentation::lessThan(
     return this->lessThan(left, right, dataRole);
   }
 
-  return AbstractProxyModel::lessThan(left, right);
+  return this->AbstractProxyModel::lessThan(left, right);
 }
 
 // ----------------------------------------------------------------------------
@@ -303,7 +303,7 @@ bool AbstractItemRepresentation::filterAcceptsRow(
     }
   }
 
-  return AbstractProxyModel::filterAcceptsRow(sourceRow, sourceParent);
+  return this->AbstractProxyModel::filterAcceptsRow(sourceRow, sourceParent);
 }
 
 // ----------------------------------------------------------------------------
@@ -322,7 +322,7 @@ bool AbstractItemRepresentation::filterAcceptsColumn(
     return false;
   }
 
-  return AbstractProxyModel::filterAcceptsColumn(
+  return this->AbstractProxyModel::filterAcceptsColumn(
     sourceColumn, sourceParent);
 }
 
@@ -331,7 +331,7 @@ void AbstractItemRepresentation::sort(int column, Qt::SortOrder order)
 {
   QTE_D();
 
-  AbstractProxyModel::sort(column, order);
+  this->AbstractProxyModel::sort(column, order);
 
   // Determine, if we are sorting (column >= 0), if QSortFilterProxyModel
   // figured out what column to sort; if not, we may need to force a sort later

--- a/sealtk/gui/AbstractItemRepresentation.hpp
+++ b/sealtk/gui/AbstractItemRepresentation.hpp
@@ -8,9 +8,9 @@
 #include <sealtk/gui/Export.h>
 #include <sealtk/gui/Enums.hpp>
 
-#include <qtGlobal.h>
+#include <sealtk/core/AbstractProxyModel.hpp>
 
-#include <QSortFilterProxyModel>
+#include <qtGlobal.h>
 
 namespace sealtk
 {
@@ -27,7 +27,7 @@ class AbstractItemRepresentationPrivate;
 /// low-level data types into data suitable for presentation, as well as common
 /// handling for handling and manipulating item visibility states.
 class SEALTK_GUI_EXPORT AbstractItemRepresentation
-  : public QSortFilterProxyModel
+  : public sealtk::core::AbstractProxyModel
 {
   Q_OBJECT
 
@@ -123,6 +123,8 @@ protected:
     return sm->data(si, role);
   }
 
+  using AbstractProxyModel::lessThan;
+
   /// Compare data for two indices.
   ///
   /// This method performs a comparison of the \p role data of two proxy
@@ -141,7 +143,7 @@ protected:
   bool filterAcceptsRow(
     int sourceRow, QModelIndex const& sourceParent) const override;
   bool filterAcceptsColumn(
-    int source_column, QModelIndex const& source_parent) const override;
+    int sourceColumn, QModelIndex const& sourceParent) const override;
 
 private:
   QTE_DECLARE_PRIVATE(AbstractItemRepresentation)

--- a/sealtk/gui/FusionModel.cpp
+++ b/sealtk/gui/FusionModel.cpp
@@ -140,7 +140,7 @@ QVariant FusionModel::data(QModelIndex const& index, int role) const
     }
   }
 
-  return AbstractItemModel::data(index, role);
+  return this->AbstractItemModel::data(index, role);
 }
 
 // ----------------------------------------------------------------------------

--- a/sealtk/gui/Player.cpp
+++ b/sealtk/gui/Player.cpp
@@ -5,9 +5,13 @@
 #include <sealtk/gui/Player.hpp>
 
 #include <sealtk/core/AutoLevelsTask.hpp>
+#include <sealtk/core/DataModelTypes.hpp>
 #include <sealtk/core/ImageUtils.hpp>
+#include <sealtk/core/ScalarFilterModel.hpp>
 
 #include <sealtk/util/unique.hpp>
+
+#include <vital/range/iota.h>
 
 #include <QApplication>
 #include <QMatrix3x3>
@@ -26,6 +30,7 @@
 #include <cmath>
 
 namespace kv = kwiver::vital;
+namespace kvr = kwiver::vital::range;
 
 namespace sealtk
 {
@@ -70,14 +75,15 @@ public:
 
   kv::timestamp timeStamp;
   kv::image_container_sptr image;
-  kv::detected_object_set_sptr detectedObjectSet;
-  std::vector<std::unique_ptr<QOpenGLBuffer>> detectedObjectVertexBuffers;
   QMatrix4x4 viewHomography;
   QMatrix4x4 homography;
   QSize homographyImageSize;
 
+  QVector<QPair<int, int>> detectedObjectVertexIndices;
+
   QOpenGLTexture imageTexture{QOpenGLTexture::Target2DArray};
   QOpenGLBuffer imageVertexBuffer{QOpenGLBuffer::VertexBuffer};
+  QOpenGLBuffer detectedObjectVertexBuffer{QOpenGLBuffer::VertexBuffer};
   QOpenGLShaderProgram imageShaderProgram;
   QOpenGLShaderProgram detectionShaderProgram;
 
@@ -104,6 +110,7 @@ public:
   bool dragging = false;
 
   core::VideoDistributor* videoSource = nullptr;
+  core::ScalarFilterModel trackModelFilter;
 };
 
 //-----------------------------------------------------------------------------
@@ -158,8 +165,13 @@ void Player::setImage(kv::image_container_sptr const& image,
   d->image = image;
   d->timeStamp = metaData.timeStamp();
 
+  auto const t = QVariant::fromValue(d->timeStamp.get_time_usec());
+  d->trackModelFilter.setUpperBound(core::StartTimeRole, t);
+  d->trackModelFilter.setLowerBound(core::EndTimeRole, t);
+
   this->makeCurrent();
   d->createTexture();
+  d->updateDetectedObjectVertexBuffers();
   this->doneCurrent();
 
   d->updateViewHomography();
@@ -173,12 +185,14 @@ void Player::setImage(kv::image_container_sptr const& image,
 }
 
 //-----------------------------------------------------------------------------
-void Player::setDetectedObjectSet(
-  kv::detected_object_set_sptr const& detectedObjectSet)
+void Player::setTrackModel(QAbstractItemModel* model)
 {
   QTE_D();
 
-  d->detectedObjectSet = detectedObjectSet;
+  connect(model, &QObject::destroyed, this,
+          [d]{ d->trackModelFilter.setSourceModel(nullptr); });
+  d->trackModelFilter.setSourceModel(model);
+
   this->makeCurrent();
   d->updateDetectedObjectVertexBuffers();
   this->doneCurrent();
@@ -250,10 +264,6 @@ void Player::setVideoSource(core::VideoDistributor* videoSource)
               [this](){
                 this->setImage(nullptr, core::VideoMetaData{});
               });
-      /* TODO
-      connect(videoSource, &core::VideoSource::detectionsReady,
-              this, &Player::setDetectedObjectSet);
-      */
     }
   }
 }
@@ -401,7 +411,11 @@ void Player::paintGL()
     auto const levelScale = 1.0f / (levels.high - levels.low);
 
     d->drawImage(levelShift, levelScale, functions);
-    d->drawDetections(functions);
+
+    if (!d->detectedObjectVertexIndices.isEmpty())
+    {
+      d->drawDetections(functions);
+    }
   }
   else
   {
@@ -578,34 +592,58 @@ void PlayerPrivate::updateViewHomography()
 //-----------------------------------------------------------------------------
 void PlayerPrivate::updateDetectedObjectVertexBuffers()
 {
-  this->detectedObjectVertexBuffers.clear();
+  QVector<float> vertexData;
 
-  if (this->detectedObjectSet)
+  // Get bounding boxes of all "active" detected objects
+  this->detectedObjectVertexIndices.clear();
+  for (auto const pr : kvr::iota(this->trackModelFilter.rowCount()))
   {
-    for (auto o : *this->detectedObjectSet)
+    auto const first = vertexData.count();
+
+    auto const& pi = this->trackModelFilter.index(pr, 0);
+    for (auto const cr : kvr::iota(this->trackModelFilter.rowCount(pi)))
     {
-      auto bbox = o->bounding_box();
-      float minX = static_cast<float>(bbox.min_x());
-      float minY = static_cast<float>(bbox.min_y());
-      float maxX = static_cast<float>(bbox.max_x());
-      float maxY = static_cast<float>(bbox.max_y());
-      QVector<QVector2D> detectedObjectVertexData{
-        {maxX, maxY},
-        {maxX, minY},
-        {minX, minY},
-        {minX, maxY},
-        {maxX, maxY},
-        {maxX, minY},
-      };
-      auto const bufSize =
-        detectedObjectVertexData.size() * static_cast<int>(sizeof(VertexData));
-      auto buf = make_unique<QOpenGLBuffer>(QOpenGLBuffer::VertexBuffer);
-      buf->create();
-      buf->bind();
-      buf->allocate(detectedObjectVertexData.data(), bufSize);
-      this->detectedObjectVertexBuffers.push_back(std::move(buf));
+      auto const& ci = this->trackModelFilter.index(cr, 0, pi);
+      auto const& cv = this->trackModelFilter.data(ci, core::VisibilityRole);
+      if (cv.toBool())
+      {
+        auto const& cd =
+          this->trackModelFilter.data(ci, core::AreaLocationRole);
+        if (cd.canConvert<QRectF>())
+        {
+          auto const& box = cd.toRectF();
+          auto const minX = static_cast<float>(box.left());
+          auto const maxX = static_cast<float>(box.right());
+          auto const minY = static_cast<float>(box.top());
+          auto const maxY = static_cast<float>(box.bottom());
+          vertexData.append(minX); vertexData.append(minY);
+          vertexData.append(maxX); vertexData.append(minY);
+          vertexData.append(maxX); vertexData.append(maxY);
+          vertexData.append(minX); vertexData.append(maxY);
+          vertexData.append(minX); vertexData.append(minY);
+        }
+      }
     }
+
+    auto const last = vertexData.count();
+    this->detectedObjectVertexIndices.append({first, last - first});
   }
+
+  if (vertexData.isEmpty())
+  {
+    return;
+  }
+
+  // Regenerate vertex buffer
+  if (!this->detectedObjectVertexBuffer.isCreated())
+  {
+    this->detectedObjectVertexBuffer.create();
+  }
+
+  this->detectedObjectVertexBuffer.bind();
+  this->detectedObjectVertexBuffer.allocate(
+    vertexData.data(), vertexData.size() * static_cast<int>(sizeof(float)));
+  this->detectedObjectVertexBuffer.release();
 }
 
 //-----------------------------------------------------------------------------
@@ -719,24 +757,29 @@ void PlayerPrivate::drawImage(float levelShift, float levelScale,
 void PlayerPrivate::drawDetections(QOpenGLFunctions* functions)
 {
   this->detectionShaderProgram.bind();
+  this->detectedObjectVertexBuffer.bind();
 
-  for (auto const& detectionBuffer : this->detectedObjectVertexBuffers)
+  this->detectionShaderProgram.setAttributeBuffer(0, GL_FLOAT, 0, 2);
+  this->detectionShaderProgram.enableAttributeArray(0);
+
+  this->detectionShaderProgram.setUniformValueArray(
+    this->detectionHomographyLocation, &this->homography, 1);
+  this->detectionShaderProgram.setUniformValueArray(
+    this->detectionViewHomographyLocation, &this->viewHomography, 1);
+
+  for (auto const& vertexInfo : this->detectedObjectVertexIndices)
   {
-    detectionBuffer->bind();
+    // TODO set color based on selection state
 
-    this->detectionShaderProgram.setAttributeBuffer(0, GL_FLOAT, 0, 2);
-    this->detectionShaderProgram.enableAttributeArray(0);
-
-    this->detectionShaderProgram.setUniformValueArray(
-      this->detectionHomographyLocation, &this->homography, 1);
-    this->detectionShaderProgram.setUniformValueArray(
-      this->detectionViewHomographyLocation, &this->viewHomography, 1);
-
-    functions->glDrawArrays(GL_LINE_STRIP, 0, 5);
-
-    detectionBuffer->release();
+    for (auto const n : kvr::iota(vertexInfo.second / 5))
+    {
+      auto const offset = vertexInfo.first + (n * 5);
+      functions->glDrawArrays(GL_LINE_STRIP, offset, 5);
+    }
   }
-  this->imageShaderProgram.release();
+
+  this->detectedObjectVertexBuffer.release();
+  this->detectionShaderProgram.release();
 }
 
 }

--- a/sealtk/gui/Player.cpp
+++ b/sealtk/gui/Player.cpp
@@ -442,7 +442,7 @@ void Player::paintEvent(QPaintEvent* event)
   QTE_D();
 
   // Handle usual GL painting
-  QOpenGLWidget::paintEvent(event);
+  this->QOpenGLWidget::paintEvent(event);
 
   // Paint text overlay, if needed
   if (!d->image)

--- a/sealtk/gui/Player.hpp
+++ b/sealtk/gui/Player.hpp
@@ -18,6 +18,7 @@
 #include <QOpenGLWidget>
 #include <QPointF>
 
+class QAbstractItemModel;
 class QImage;
 class QMatrix4x4;
 
@@ -58,8 +59,7 @@ signals:
 public slots:
   virtual void setImage(kwiver::vital::image_container_sptr const& image,
                         sealtk::core::VideoMetaData const& metaData);
-  virtual void setDetectedObjectSet(
-    kwiver::vital::detected_object_set_sptr const& detectedObjectSet);
+  void setTrackModel(QAbstractItemModel* model);
   void setHomography(QMatrix4x4 const& homography);
   void setHomographyImageSize(QSize size);
   void setZoom(float zoom);

--- a/sealtk/gui/test/AbstractItemRepresentation.cpp
+++ b/sealtk/gui/test/AbstractItemRepresentation.cpp
@@ -97,7 +97,7 @@ QVariant TestModel::data(QModelIndex const& index, int role) const
       return visibilityData[r];
 
     default:
-      return AbstractItemModel::data(index, role);
+      return this->AbstractItemModel::data(index, role);
   }
 }
 

--- a/sealtk/noaa/gui/Window.cpp
+++ b/sealtk/noaa/gui/Window.cpp
@@ -375,6 +375,7 @@ void WindowPrivate::loadDetections(WindowData* data)
       [data, this](std::shared_ptr<QAbstractItemModel> const& model){
         data->trackModel = model;
         this->trackModel.addModel(model.get());
+        data->player->setTrackModel(model.get());
       });
     QObject::connect(
       data->trackSource.get(), &sc::AbstractDataSource::failed, q,


### PR DESCRIPTION
Add detections/states to `KwiverTrackModel`, so that we have a way with the new data model framework to get bounding boxes. Add `ScalarFilterModel`, to filter a model based on scalar bounds, which will be used to determine what boxes should be shown on a given frame. Update detection rendering code to use these.