### PR TITLE
Save UI state of NOAA GUI

### DIFF
--- a/sealtk/noaa/Main.cpp
+++ b/sealtk/noaa/Main.cpp
@@ -30,6 +30,7 @@ int main(int argc, char** argv)
   QApplication app{argc, argv};
   QApplication::setApplicationName("SEAL-TK");
   QApplication::setApplicationVersion(QStringLiteral(SEALTK_VERSION));
+  QApplication::setOrganizationName("Kitware");
 
   QCommandLineParser parser;
   parser.setApplicationDescription(

--- a/sealtk/noaa/gui/Window.cpp
+++ b/sealtk/noaa/gui/Window.cpp
@@ -28,6 +28,7 @@
 #include <sealtk/gui/SplitterWindow.hpp>
 
 #include <qtStlUtil.h>
+#include <qtUiState.h>
 
 #include <QCollator>
 #include <QDebug>
@@ -115,6 +116,7 @@ public:
   void executePipeline(QString const& pipelineFile);
 
   Ui::Window ui;
+  qtUiState uiState;
 
   sg::FusionModel trackModel;
   TrackRepresentation trackRepresentation;
@@ -190,11 +192,28 @@ Window::Window(QWidget* parent)
   d->registerVideoSourceFactory(
     "Image Directory...",
     new core::ImageListVideoSourceFactory{true, d->videoController.get()});
+
+  d->uiState.mapState("Window/state", this);
+  d->uiState.mapGeometry("Window/geometry", this);
+  d->uiState.mapState("Window/splitter", d->ui.centralwidget);
+  d->uiState.mapState("Tracks/state", d->ui.tracks->header());
+
+  d->uiState.restore();
 }
 
 //-----------------------------------------------------------------------------
 Window::~Window()
 {
+}
+
+//-----------------------------------------------------------------------------
+void Window::closeEvent(QCloseEvent* e)
+{
+  QTE_D();
+
+  d->uiState.save();
+
+  QMainWindow::closeEvent(e);
 }
 
 //-----------------------------------------------------------------------------

--- a/sealtk/noaa/gui/Window.hpp
+++ b/sealtk/noaa/gui/Window.hpp
@@ -53,6 +53,8 @@ public slots:
 protected:
   QTE_DECLARE_PRIVATE(Window)
 
+  void closeEvent(QCloseEvent* event) override;
+
 private:
   QTE_DECLARE_PRIVATE_RPTR(Window)
 };


### PR DESCRIPTION
Add UI state persistence to the NOAA GUI. This way users can arrange things to their liking and not have to redo it every time they restart the application.

(Depends on kitware/qtextensions#26.)