### PR TITLE
Update view transform on changing scene transform

### DIFF
--- a/sealtk/gui/Player.cpp
+++ b/sealtk/gui/Player.cpp
@@ -205,7 +205,7 @@ void Player::setHomography(QMatrix4x4 const& homography)
   QTE_D();
 
   d->homography = homography;
-  this->update();
+  d->updateViewHomography();
 }
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
Tweak our code to set the scene transform (homography) to also force an update of the view transform. This is needed because the view transform depends on whether or not we have a non-identity scene transform active. Previously, the view would not update correctly when a scene transform is initially loaded.

I believe this is correct, but it would be good if @mattdawkins could also test.