### PR TITLE
TimeMap test polishing

### DIFF
--- a/sealtk/core/TimeMap.hpp
+++ b/sealtk/core/TimeMap.hpp
@@ -5,11 +5,16 @@
 #ifndef sealtk_core_TimeMap_hpp
 #define sealtk_core_TimeMap_hpp
 
+#include <sealtk/core/Export.h>
+
 #include <vital/types/timestamp.h>
 
 #include <qtEnumerate.h>
+#include <qtGlobal.h>
 
 #include <QMap>
+#include <QMetaObject>
+#include <QMetaType>
 #include <QSet>
 
 namespace sealtk
@@ -17,6 +22,8 @@ namespace sealtk
 
 namespace core
 {
+
+QTE_BEGIN_META_NAMESPACE(SEALTK_CORE_EXPORT, time_map_enums)
 
 /// Requested seek mode.
 ///
@@ -62,6 +69,10 @@ enum SeekMode
   /// \sa ::SeekUpperBound
   SeekPrevious
 };
+
+QTE_ENUM_NS(SeekMode)
+
+QTE_END_META_NAMESPACE()
 
 // ============================================================================
 template <typename Value>
@@ -252,5 +263,7 @@ void TimeMap<Value>::insert(TimeMap<Value> const& other)
 } // namespace core
 
 } // namespace sealtk
+
+Q_DECLARE_METATYPE(sealtk::core::SeekMode)
 
 #endif

--- a/sealtk/core/test/TimeMap.cpp
+++ b/sealtk/core/test/TimeMap.cpp
@@ -34,48 +34,45 @@ private slots:
 // ----------------------------------------------------------------------------
 void TestTimeMap::find()
 {
-  // For sake of simplicity in testing, 0 means "not found".
+  // For the sake of simplicity in testing, expected == 0 means that we expect
+  // the seek operations to "fail" (return an invalid iterator).
 
   QFETCH(TimeMap<int>, data);
   QFETCH(kv::timestamp::time_t, searchValue);
-  QFETCH(int, seekMode);
+  QFETCH(SeekMode, seekMode);
   QFETCH(int, expected);
 
-  SeekMode realSeekMode = static_cast<SeekMode>(seekMode);
-
   // find()
-  auto result = data.find(searchValue, realSeekMode);
+  auto const result1 = data.find(searchValue, seekMode);
   if (expected)
   {
-    QCOMPARE(*result, expected);
+    QCOMPARE(*result1, expected);
   }
   else
   {
-    QCOMPARE(result, data.end());
+    QCOMPARE(result1, data.end());
   }
-
-  TimeMap<int> const constData{data};
 
   // find() const
-  auto constResult = constData.find(searchValue, realSeekMode);
+  auto const result2 = qAsConst(data).find(searchValue, seekMode);
   if (expected)
   {
-    QCOMPARE(*constResult, expected);
+    QCOMPARE(*result2, expected);
   }
   else
   {
-    QCOMPARE(constResult, constData.end());
+    QCOMPARE(result2, qAsConst(data).end());
   }
 
   // constFind() const
-  constResult = constData.constFind(searchValue, realSeekMode);
+  auto const result3 = data.constFind(searchValue, seekMode);
   if (expected)
   {
-    QCOMPARE(*constResult, expected);
+    QCOMPARE(*result3, expected);
   }
   else
   {
-    QCOMPARE(constResult, constData.end());
+    QCOMPARE(result3, data.constEnd());
   }
 }
 
@@ -92,129 +89,130 @@ void TestTimeMap::find_data()
 
   QTest::addColumn<TimeMap<int>>("data");
   QTest::addColumn<kv::timestamp::time_t>("searchValue");
-  QTest::addColumn<int>("seekMode");
+  QTest::addColumn<SeekMode>("seekMode");
   QTest::addColumn<int>("expected");
 
-  QTest::newRow("Nearest_exact") << data << 1000l
-    << static_cast<int>(sealtk::core::SeekNearest) << 2;
-  QTest::newRow("Nearest_down") << data << 1249l
-    << static_cast<int>(sealtk::core::SeekNearest) << 2;
-  QTest::newRow("Nearest_up") << data << 1251l
-    << static_cast<int>(sealtk::core::SeekNearest) << 3;
-  QTest::newRow("Nearest_split") << data << 2500l
-    << static_cast<int>(sealtk::core::SeekNearest) << 4;
-  QTest::newRow("Nearest_low") << data << -1000l
-    << static_cast<int>(sealtk::core::SeekNearest) << 1;
-  QTest::newRow("Nearest_high") << data << 4000l
-    << static_cast<int>(sealtk::core::SeekNearest) << 5;
-  QTest::newRow("Nearest_lowerbound") << data << 0l
-    << static_cast<int>(sealtk::core::SeekNearest) << 1;
-  QTest::newRow("Nearest_upperbound") << data << 3000l
-    << static_cast<int>(sealtk::core::SeekNearest) << 5;
-  QTest::newRow("Nearest_empty") << TimeMap<int>{} << 2500l
-    << static_cast<int>(sealtk::core::SeekNearest) << 0;
+  QTest::newRow("Nearest (exact match)")
+    << data <<  1000l << SeekNearest << 2;
+  QTest::newRow("Nearest (earlier match)")
+    << data <<  1249l << SeekNearest << 2;
+  QTest::newRow("Nearest (later match)")
+    << data <<  1251l << SeekNearest << 3;
+  QTest::newRow("Nearest (tied match)")
+    << data <<  2500l << SeekNearest << 4;
+  QTest::newRow("Nearest (before start)")
+    << data << -1000l << SeekNearest << 1;
+  QTest::newRow("Nearest (after end)")
+    << data <<  4000l << SeekNearest << 5;
+  QTest::newRow("Nearest (equals start)")
+    << data << 0l << SeekNearest << 1;
+  QTest::newRow("Nearest (equals end)")
+    << data << 3000l << SeekNearest << 5;
+  QTest::newRow("Nearest (on empty map)")
+    << TimeMap<int>{} << 2500l << SeekNearest << 0;
 
-  QTest::newRow("LowerBound_exact") << data << 1000l
-    << static_cast<int>(sealtk::core::SeekLowerBound) << 2;
-  QTest::newRow("LowerBound_down") << data << 1249l
-    << static_cast<int>(sealtk::core::SeekLowerBound) << 3;
-  QTest::newRow("LowerBound_up") << data << 1251l
-    << static_cast<int>(sealtk::core::SeekLowerBound) << 3;
-  QTest::newRow("LowerBound_split") << data << 2500l
-    << static_cast<int>(sealtk::core::SeekLowerBound) << 5;
-  QTest::newRow("LowerBound_low") << data << -1000l
-    << static_cast<int>(sealtk::core::SeekLowerBound) << 1;
-  QTest::newRow("LowerBound_high") << data << 4000l
-    << static_cast<int>(sealtk::core::SeekLowerBound) << 0;
-  QTest::newRow("LowerBound_lowerbound") << data << 0l
-    << static_cast<int>(sealtk::core::SeekLowerBound) << 1;
-  QTest::newRow("LowerBound_upperbound") << data << 3000l
-    << static_cast<int>(sealtk::core::SeekLowerBound) << 5;
-  QTest::newRow("LowerBound_empty") << TimeMap<int>{} << 2500l
-    << static_cast<int>(sealtk::core::SeekLowerBound) << 0;
+  QTest::newRow("LowerBound (exact match)")
+    << data << 1000l << SeekLowerBound << 2;
+  QTest::newRow("LowerBound (near earlier match)")
+    << data << 1001l << SeekLowerBound << 3;
+  QTest::newRow("LowerBound (near later match)")
+    << data << 1499l << SeekLowerBound << 3;
+  QTest::newRow("LowerBound (tied match)")
+    << data << 2500l << SeekLowerBound << 5;
+  QTest::newRow("LowerBound (before start)")
+    << data << -1000l << SeekLowerBound << 1;
+  QTest::newRow("LowerBound (after end)")
+    << data << 4000l << SeekLowerBound << 0;
+  QTest::newRow("LowerBound (equals start)")
+    << data << 0l << SeekLowerBound << 1;
+  QTest::newRow("LowerBound (equals end)")
+    << data << 3000l << SeekLowerBound << 5;
+  QTest::newRow("LowerBound (on empty map)")
+    << TimeMap<int>{} << 2500l << SeekLowerBound << 0;
 
-  QTest::newRow("UpperBound_exact") << data << 1000l
-    << static_cast<int>(sealtk::core::SeekUpperBound) << 2;
-  QTest::newRow("UpperBound_down") << data << 1249l
-    << static_cast<int>(sealtk::core::SeekUpperBound) << 2;
-  QTest::newRow("UpperBound_up") << data << 1251l
-    << static_cast<int>(sealtk::core::SeekUpperBound) << 2;
-  QTest::newRow("UpperBound_split") << data << 2500l
-    << static_cast<int>(sealtk::core::SeekUpperBound) << 4;
-  QTest::newRow("UpperBound_low") << data << -1000l
-    << static_cast<int>(sealtk::core::SeekUpperBound) << 0;
-  QTest::newRow("UpperBound_high") << data << 4000l
-    << static_cast<int>(sealtk::core::SeekUpperBound) << 5;
-  QTest::newRow("UpperBound_lowerbound") << data << 0l
-    << static_cast<int>(sealtk::core::SeekUpperBound) << 1;
-  QTest::newRow("UpperBound_upperbound") << data << 3000l
-    << static_cast<int>(sealtk::core::SeekUpperBound) << 5;
-  QTest::newRow("UpperBound_empty") << TimeMap<int>{} << 2500l
-    << static_cast<int>(sealtk::core::SeekUpperBound) << 0;
+  QTest::newRow("UpperBound (exact match)")
+    << data << 1000l << SeekUpperBound << 2;
+  QTest::newRow("UpperBound (near earlier match)")
+    << data << 1001l << SeekUpperBound << 2;
+  QTest::newRow("UpperBound (near later match)")
+    << data << 1499l << SeekUpperBound << 2;
+  QTest::newRow("UpperBound (tied match)")
+    << data << 2500l << SeekUpperBound << 4;
+  QTest::newRow("UpperBound (before start)")
+    << data << -1000l << SeekUpperBound << 0;
+  QTest::newRow("UpperBound (after end)")
+    << data << 4000l << SeekUpperBound << 5;
+  QTest::newRow("UpperBound (equals start)")
+    << data << 0l << SeekUpperBound << 1;
+  QTest::newRow("UpperBound (equals end)")
+    << data << 3000l << SeekUpperBound << 5;
+  QTest::newRow("UpperBound (on empty map)")
+    << TimeMap<int>{} << 2500l << SeekUpperBound << 0;
 
-  QTest::newRow("Exact_exact") << data << 1000l
-    << static_cast<int>(sealtk::core::SeekExact) << 2;
-  QTest::newRow("Exact_down") << data << 1249l
-    << static_cast<int>(sealtk::core::SeekExact) << 0;
-  QTest::newRow("Exact_up") << data << 1251l
-    << static_cast<int>(sealtk::core::SeekExact) << 0;
-  QTest::newRow("Exact_split") << data << 2500l
-    << static_cast<int>(sealtk::core::SeekExact) << 0;
-  QTest::newRow("Exact_low") << data << -1000l
-    << static_cast<int>(sealtk::core::SeekExact) << 0;
-  QTest::newRow("Exact_high") << data << 4000l
-    << static_cast<int>(sealtk::core::SeekExact) << 0;
-  QTest::newRow("Exact_lowerbound") << data << 0l
-    << static_cast<int>(sealtk::core::SeekExact) << 1;
-  QTest::newRow("Exact_upperbound") << data << 3000l
-    << static_cast<int>(sealtk::core::SeekExact) << 5;
-  QTest::newRow("Exact_empty") << TimeMap<int>{} << 2500l
-    << static_cast<int>(sealtk::core::SeekExact) << 0;
+  QTest::newRow("Exact (exact match)")
+    << data << 1000l << SeekExact << 2;
+  QTest::newRow("Exact (near earlier match)")
+    << data << 1001l << SeekExact << 0;
+  QTest::newRow("Exact (near later match)")
+    << data << 1499l << SeekExact << 0;
+  QTest::newRow("Exact (tied match)")
+    << data << 2500l << SeekExact << 0;
+  QTest::newRow("Exact (before start)")
+    << data << -1000l << SeekExact << 0;
+  QTest::newRow("Exact (after end)")
+    << data << 4000l << SeekExact << 0;
+  QTest::newRow("Exact (equals start)")
+    << data << 0l << SeekExact << 1;
+  QTest::newRow("Exact (equals end)")
+    << data << 3000l << SeekExact << 5;
+  QTest::newRow("Exact (on empty map)")
+    << TimeMap<int>{} << 2500l << SeekExact << 0;
 
-  QTest::newRow("Next_exact") << data << 1000l
-    << static_cast<int>(sealtk::core::SeekNext) << 3;
-  QTest::newRow("Next_down") << data << 1249l
-    << static_cast<int>(sealtk::core::SeekNext) << 3;
-  QTest::newRow("Next_up") << data << 1251l
-    << static_cast<int>(sealtk::core::SeekNext) << 3;
-  QTest::newRow("Next_split") << data << 2500l
-    << static_cast<int>(sealtk::core::SeekNext) << 5;
-  QTest::newRow("Next_low") << data << -1000l
-    << static_cast<int>(sealtk::core::SeekNext) << 1;
-  QTest::newRow("Next_high") << data << 4000l
-    << static_cast<int>(sealtk::core::SeekNext) << 0;
-  QTest::newRow("Next_lowerbound") << data << 0l
-    << static_cast<int>(sealtk::core::SeekNext) << 2;
-  QTest::newRow("Next_upperbound") << data << 3000l
-    << static_cast<int>(sealtk::core::SeekNext) << 0;
-  QTest::newRow("Next_empty") << TimeMap<int>{} << 2500l
-    << static_cast<int>(sealtk::core::SeekNext) << 0;
+  QTest::newRow("Next (exact match)")
+    << data << 1000l << SeekNext << 3;
+  QTest::newRow("Next (near earlier match)")
+    << data << 1001l << SeekNext << 3;
+  QTest::newRow("Next (near later match)")
+    << data << 1499l << SeekNext << 3;
+  QTest::newRow("Next (tied match)")
+    << data << 2500l << SeekNext << 5;
+  QTest::newRow("Next (before start)")
+    << data << -1000l << SeekNext << 1;
+  QTest::newRow("Next (after end)")
+    << data << 4000l << SeekNext << 0;
+  QTest::newRow("Next (equals start)")
+    << data << 0l << SeekNext << 2;
+  QTest::newRow("Next (equals end)")
+    << data << 3000l << SeekNext << 0;
+  QTest::newRow("Next (on empty map)")
+    << TimeMap<int>{} << 2500l << SeekNext << 0;
 
-  QTest::newRow("Previous_exact") << data << 1000l
-    << static_cast<int>(sealtk::core::SeekPrevious) << 1;
-  QTest::newRow("Previous_down") << data << 1249l
-    << static_cast<int>(sealtk::core::SeekPrevious) << 2;
-  QTest::newRow("Previous_up") << data << 1251l
-    << static_cast<int>(sealtk::core::SeekPrevious) << 2;
-  QTest::newRow("Previous_split") << data << 2500l
-    << static_cast<int>(sealtk::core::SeekPrevious) << 4;
-  QTest::newRow("Previous_low") << data << -1000l
-    << static_cast<int>(sealtk::core::SeekPrevious) << 0;
-  QTest::newRow("Previous_high") << data << 4000l
-    << static_cast<int>(sealtk::core::SeekPrevious) << 5;
-  QTest::newRow("Previous_lowerbound") << data << 0l
-    << static_cast<int>(sealtk::core::SeekPrevious) << 0;
-  QTest::newRow("Previous_upperbound") << data << 3000l
-    << static_cast<int>(sealtk::core::SeekPrevious) << 4;
-  QTest::newRow("Previous_empty") << TimeMap<int>{} << 2500l
-    << static_cast<int>(sealtk::core::SeekPrevious) << 0;
+  QTest::newRow("Previous (exact match)")
+    << data << 1000l << SeekPrevious << 1;
+  QTest::newRow("Previous (near earlier match)")
+    << data << 1001l << SeekPrevious << 2;
+  QTest::newRow("Previous (near later match)")
+    << data << 1499l << SeekPrevious << 2;
+  QTest::newRow("Previous (tied match)")
+    << data << 2500l << SeekPrevious << 4;
+  QTest::newRow("Previous (before start)")
+    << data << -1000l << SeekPrevious << 0;
+  QTest::newRow("Previous (after end)")
+    << data << 4000l << SeekPrevious << 5;
+  QTest::newRow("Previous (equals start)")
+    << data << 0l << SeekPrevious << 0;
+  QTest::newRow("Previous (equals end)")
+    << data << 3000l << SeekPrevious << 4;
+  QTest::newRow("Previous (on empty map)")
+    << TimeMap<int>{} << 2500l << SeekPrevious << 0;
 }
 
-}
+} // namespace test
 
-}
+} // namespace core
 
-}
+} // namespace sealtk
 
+// ----------------------------------------------------------------------------
 QTEST_MAIN(sealtk::core::test::TestTimeMap)
 #include "TimeMap.moc"


### PR DESCRIPTION
Add meta-information to the `SeekMode` enumeration used by `TimeMap`. Modify the `TimeMap` test to directly pass the seek mode. Also, improve the test names and an explanatory comment, and fix some style inconsistencies.

Depends on kitware/qtextensions#28.