### PR TITLE
 Implement getting detections from pipelines

### DIFF
--- a/sealtk/core/AbstractItemModel.cpp
+++ b/sealtk/core/AbstractItemModel.cpp
@@ -66,6 +66,34 @@ QVariant AbstractItemModel::data(QModelIndex const& index, int role) const
   }
 }
 
+// ----------------------------------------------------------------------------
+void AbstractItemModel::emitDataChanged(
+  QModelIndex const& parent, QList<int>&& rows, QVector<int> const& roles)
+{
+  qSort(rows.begin(), rows.end());
+
+  auto first = rows.takeFirst();
+  auto last = first;
+
+  for (auto const row : rows)
+  {
+    if (row != last + 1)
+    {
+      emit this->dataChanged(
+        this->index(first, 0, parent),
+        this->index(last, 0, parent),
+        roles);
+      first = row;
+    }
+    last = row;
+  }
+
+  emit this->dataChanged(
+    this->index(first, 0, parent),
+    this->index(last, 0, parent),
+    roles);
+}
+
 } // namespace core
 
 } // namespace sealtk

--- a/sealtk/core/AbstractItemModel.hpp
+++ b/sealtk/core/AbstractItemModel.hpp
@@ -45,6 +45,9 @@ public:
 protected:
   static constexpr auto IndexIsValid = CheckIndexOption::IndexIsValid;
   static constexpr auto ParentIsInvalid = CheckIndexOption::ParentIsInvalid;
+
+  void emitDataChanged(QModelIndex const& parent, QList<int>&& rows,
+                       QVector<int> const& roles = {});
 };
 
 } // namespace core

--- a/sealtk/core/AbstractProxyModel.cpp
+++ b/sealtk/core/AbstractProxyModel.cpp
@@ -89,6 +89,18 @@ bool AbstractProxyModel::lessThan(
   }
 }
 
+// ----------------------------------------------------------------------------
+void AbstractProxyModel::invalidateVisibility()
+{
+  if (auto const rows = this->rowCount())
+  {
+    auto const& first = this->index(0, 0);
+    auto const& last = this->index(rows, 0);
+
+    emit this->dataChanged(first, last, {VisibilityRole});
+  }
+}
+
 } // namespace core
 
 } // namespace sealtk

--- a/sealtk/core/AbstractProxyModel.hpp
+++ b/sealtk/core/AbstractProxyModel.hpp
@@ -47,6 +47,13 @@ protected:
     QVariant const& left, QVariant const& right, int role) const;
 
   using QSortFilterProxyModel::lessThan;
+
+  /// Emit dataChanged for all top-level items.
+  ///
+  /// This method emits QAbstractItemModel::dataChanged for all top-level
+  /// items, with #VisibilityRole as the list of changed roles. This is useful
+  /// for model data filters when their filtering criteria changes.
+  void invalidateVisibility();
 };
 
 } // namespace core

--- a/sealtk/core/CMakeLists.txt
+++ b/sealtk/core/CMakeLists.txt
@@ -24,6 +24,7 @@ sealtk_add_library(sealtk::core
     KwiverFileVideoSourceFactory.cpp
     KwiverDetectionsSink.cpp
     KwiverTrackModel.cpp
+    KwiverPipelinePortSet.cpp
     KwiverPipelineWorker.cpp
     KwiverTrackSource.cpp
     KwiverVideoSource.cpp
@@ -51,6 +52,7 @@ sealtk_add_library(sealtk::core
     KwiverFileVideoSourceFactory.hpp
     KwiverDetectionsSink.hpp
     KwiverTrackModel.hpp
+    KwiverPipelinePortSet.hpp
     KwiverPipelineWorker.hpp
     KwiverTrackSource.hpp
     KwiverVideoSource.hpp

--- a/sealtk/core/KwiverPipelinePortSet.cpp
+++ b/sealtk/core/KwiverPipelinePortSet.cpp
@@ -1,0 +1,69 @@
+/* This file is part of SEAL-TK, and is distributed under the OSI-approved BSD
+ * 3-Clause License. See top-level LICENSE file or
+ * https://github.com/Kitware/seal-tk/blob/master/LICENSE for details. */
+
+#include <sealtk/core/KwiverPipelinePortSet.hpp>
+
+namespace sealtk
+{
+
+namespace core
+{
+
+namespace // anonymous
+{
+
+// ----------------------------------------------------------------------------
+void bind(std::string& out, std::string const& expected, std::string const& in)
+{
+  if (in == expected)
+  {
+    out = expected;
+  }
+}
+
+}
+
+// ----------------------------------------------------------------------------
+void KwiverPipelinePortSet::bind(
+  kwiver::embedded_pipeline& pipeline, int index, PortType type,
+  std::vector<PortReference> additionalPorts)
+{
+  auto const timePortName = this->portName("timestamp", index);
+
+  for (auto const& p : this->portNames(pipeline, type))
+  {
+    sealtk::core::bind(this->timePort, timePortName, p);
+    for (auto const& ap : additionalPorts)
+    {
+      sealtk::core::bind(ap.first, ap.second, p);
+    }
+  }
+}
+
+// ----------------------------------------------------------------------------
+sprokit::process::ports_t KwiverPipelinePortSet::portNames(
+  kwiver::embedded_pipeline& pipeline, PortType type)
+{
+  switch (type)
+  {
+    case PortType::Input: return pipeline.input_port_names();
+    case PortType::Output: return pipeline.output_port_names();
+    default: return {};
+  }
+}
+
+// ----------------------------------------------------------------------------
+std::string KwiverPipelinePortSet::portName(std::string const& base, int index)
+{
+  if (index)
+  {
+    return base + std::to_string(index + 1);
+  }
+
+  return base;
+}
+
+} // namespace core
+
+} // namespace sealtk

--- a/sealtk/core/KwiverPipelinePortSet.hpp
+++ b/sealtk/core/KwiverPipelinePortSet.hpp
@@ -1,0 +1,90 @@
+/* This file is part of SEAL-TK, and is distributed under the OSI-approved BSD
+ * 3-Clause License. See top-level LICENSE file or
+ * https://github.com/Kitware/seal-tk/blob/master/LICENSE for details. */
+
+#ifndef sealtk_core_KwiverPipelinePortSet_hpp
+#define sealtk_core_KwiverPipelinePortSet_hpp
+
+#include <sealtk/core/Export.h>
+
+#include <sprokit/processes/adapters/adapter_data_set.h>
+#include <sprokit/processes/adapters/embedded_pipeline.h>
+
+#include <string>
+#include <vector>
+
+namespace sealtk
+{
+
+namespace core
+{
+
+// ============================================================================
+class SEALTK_CORE_EXPORT KwiverPipelinePortSet
+{
+public:
+  static std::string portName(std::string const& base, int index);
+
+protected:
+  using PortReference = std::pair<std::string&, std::string>;
+
+  enum class PortType
+  {
+    Input,
+    Output,
+  };
+
+  KwiverPipelinePortSet() = default;
+  ~KwiverPipelinePortSet() = default;
+
+  void bind(
+    kwiver::embedded_pipeline& pipeline, int index, PortType type,
+    std::vector<PortReference> additionalPorts);
+
+  static sprokit::process::ports_t portNames(
+    kwiver::embedded_pipeline& pipeline, PortType type);
+
+  template <typename T>
+  static void addInput(kwiver::adapter::adapter_data_set_t const& dataSet,
+                       std::string const& portName, T const& data);
+
+  template <typename T>
+  static void ensureInput(kwiver::adapter::adapter_data_set_t const& dataSet,
+                          std::string const& portName, T const& data);
+
+  std::string timePort;
+};
+
+// ----------------------------------------------------------------------------
+template <typename T>
+void KwiverPipelinePortSet::addInput(
+  kwiver::adapter::adapter_data_set_t const& dataSet,
+  std::string const& portName, T const& data)
+{
+  if (!portName.empty())
+  {
+    dataSet->add_value(portName, data);
+  }
+}
+
+// ----------------------------------------------------------------------------
+template <typename T>
+void KwiverPipelinePortSet::ensureInput(
+  kwiver::adapter::adapter_data_set_t const& dataSet,
+  std::string const& portName, T const& data)
+{
+  if (!portName.empty())
+  {
+    auto const& iter = dataSet->find(portName);
+    if (iter == dataSet->end())
+    {
+      dataSet->add_value(portName, data);
+    }
+  }
+}
+
+} // namespace core
+
+} // namespace sealtk
+
+#endif

--- a/sealtk/core/KwiverPipelineWorker.cpp
+++ b/sealtk/core/KwiverPipelineWorker.cpp
@@ -4,15 +4,13 @@
 
 #include <sealtk/core/KwiverPipelineWorker.hpp>
 
+#include <sealtk/core/KwiverPipelinePortSet.hpp>
 #include <sealtk/core/VideoFrame.hpp>
 #include <sealtk/core/VideoRequest.hpp>
 #include <sealtk/core/VideoRequestor.hpp>
 #include <sealtk/core/VideoSource.hpp>
 
 #include <sealtk/util/unique.hpp>
-
-#include <sprokit/processes/adapters/adapter_data_set.h>
-#include <sprokit/processes/adapters/embedded_pipeline.h>
 
 #include <vital/range/iota.h>
 
@@ -40,7 +38,7 @@ namespace // anonymous
 {
 
 // ============================================================================
-class PortSet
+class PortSet : public KwiverPipelinePortSet
 {
 public:
   PortSet(kwiver::embedded_pipeline& pipeline, int index);
@@ -50,39 +48,19 @@ public:
   void ensureInputs(ka::adapter_data_set_t const& dataSet);
 
 private:
-  static std::string portName(std::string const& base, int index);
-
-  static void bind(std::string& out, std::string const& expected,
-                   std::string const& in);
-
-  template <typename T>
-  static void addInput(ka::adapter_data_set_t const& dataSet,
-                       std::string const& portName, T const& data);
-
-  template <typename T>
-  static void ensureInput(ka::adapter_data_set_t const& dataSet,
-                          std::string const& portName, T const& data);
-
   std::string imagePort;
   std::string namePort;
-  std::string timePort;
 };
 
 // ----------------------------------------------------------------------------
 PortSet::PortSet(kwiver::embedded_pipeline& pipeline, int index)
 {
-  using std::string;
-
-  auto const imagePortName = this->portName("image", index);
-  auto const namePortName = this->portName("file_name", index);
-  auto const timePortName = this->portName("timestamp", index);
-
-  for (auto const& p : pipeline.input_port_names())
-  {
-    this->bind(this->imagePort, imagePortName, p);
-    this->bind(this->namePort, namePortName, p);
-    this->bind(this->timePort, timePortName, p);
-  }
+  KwiverPipelinePortSet::bind(
+    pipeline, index, PortType::Input,
+    {
+      {this->imagePort, this->portName("image", index)},
+      {this->namePort, this->portName("file_name", index)},
+    });
 }
 
 // ----------------------------------------------------------------------------
@@ -102,53 +80,6 @@ void PortSet::ensureInputs(ka::adapter_data_set_t const& dataSet)
   this->ensureInput(dataSet, this->imagePort, kv::image_container_sptr{});
   this->ensureInput(dataSet, this->namePort, kv::path_t{});
   this->ensureInput(dataSet, this->timePort, kv::timestamp{});
-}
-
-// ----------------------------------------------------------------------------
-template <typename T>
-void PortSet::addInput(ka::adapter_data_set_t const& dataSet,
-                       std::string const& portName, T const& data)
-{
-  if (!portName.empty())
-  {
-    dataSet->add_value(portName, data);
-  }
-}
-
-// ----------------------------------------------------------------------------
-template <typename T>
-void PortSet::ensureInput(ka::adapter_data_set_t const& dataSet,
-                          std::string const& portName, T const& data)
-{
-  if (!portName.empty())
-  {
-    auto const& iter = dataSet->find(portName);
-    if (iter == dataSet->end())
-    {
-      dataSet->add_value(portName, data);
-    }
-  }
-}
-
-// ----------------------------------------------------------------------------
-std::string PortSet::portName(std::string const& base, int index)
-{
-  if (index)
-  {
-    return base + std::to_string(index + 1);
-  }
-
-  return base;
-}
-
-// ----------------------------------------------------------------------------
-void PortSet::bind(std::string& out, std::string const& expected,
-                   std::string const& in)
-{
-  if (in == expected)
-  {
-    out = expected;
-  }
 }
 
 // ============================================================================

--- a/sealtk/core/KwiverPipelineWorker.cpp
+++ b/sealtk/core/KwiverPipelineWorker.cpp
@@ -423,6 +423,6 @@ void KwiverPipelineWorker::reportError(
   QMessageBox::warning(w, subject, message);
 }
 
-} // namespace tools
+} // namespace core
 
-} // namespace kwiver
+} // namespace sealtk

--- a/sealtk/core/KwiverTrackModel.cpp
+++ b/sealtk/core/KwiverTrackModel.cpp
@@ -256,7 +256,7 @@ void KwiverTrackModel::addTracks(
     auto const oldRows = this->rowCount({});
     auto const newRows = newTracks.size();
 
-    this->beginInsertRows({}, oldRows, newRows);
+    this->beginInsertRows({}, oldRows, oldRows + newRows - 1);
 
     for (auto& track : newTracks)
     {

--- a/sealtk/core/ScalarFilterModel.cpp
+++ b/sealtk/core/ScalarFilterModel.cpp
@@ -54,7 +54,7 @@ void ScalarFilterModel::setLowerBound(int role, QVariant const& bound)
     if (bound != old.first)
     {
       old.first = bound;
-      this->invalidate();
+      this->invalidateVisibility();
     }
   }
 }
@@ -70,7 +70,7 @@ void ScalarFilterModel::setUpperBound(int role, QVariant const& bound)
     if (bound != old.second)
     {
       old.second = bound;
-      this->invalidate();
+      this->invalidateVisibility();
     }
   }
 }
@@ -88,7 +88,7 @@ void ScalarFilterModel::setBound(
     {
       old.first = lower;
       old.second = upper;
-      this->invalidate();
+      this->invalidateVisibility();
     }
   }
 }
@@ -110,7 +110,7 @@ void ScalarFilterModel::clearLowerBound(int role)
       d->bounds.erase(i);
     }
 
-    this->invalidate();
+    this->invalidateVisibility();
   }
 }
 
@@ -131,7 +131,7 @@ void ScalarFilterModel::clearUpperBound(int role)
       d->bounds.erase(i);
     }
 
-    this->invalidate();
+    this->invalidateVisibility();
   }
 }
 
@@ -142,7 +142,7 @@ void ScalarFilterModel::clearBound(int role)
 
   if (d->bounds.remove(role))
   {
-    this->invalidate();
+    this->invalidateVisibility();
   }
 }
 
@@ -154,7 +154,7 @@ void ScalarFilterModel::clearBounds()
   if (!d->bounds.isEmpty())
   {
     d->bounds.clear();
-    this->invalidate();
+    this->invalidateVisibility();
   }
 }
 

--- a/sealtk/noaa/core/CMakeLists.txt
+++ b/sealtk/noaa/core/CMakeLists.txt
@@ -25,10 +25,12 @@ sealtk_add_library(sealtk::noaa_core
   SOURCES
     FilenameUtils.cpp
     ImageListVideoSourceFactory.cpp
+    NoaaPipelineWorker.cpp
 
   HEADERS
     FilenameUtils.hpp
     ImageListVideoSourceFactory.hpp
+    NoaaPipelineWorker.hpp
     "${CMAKE_CURRENT_BINARY_DIR}/Config.h"
 
   PUBLIC_LINK_LIBRARIES

--- a/sealtk/noaa/core/NoaaPipelineWorker.cpp
+++ b/sealtk/noaa/core/NoaaPipelineWorker.cpp
@@ -1,0 +1,215 @@
+/* This file is part of SEAL-TK, and is distributed under the OSI-approved BSD
+ * 3-Clause License. See top-level LICENSE file or
+ * https://github.com/Kitware/seal-tk/blob/master/LICENSE for details. */
+
+#include <sealtk/noaa/core/NoaaPipelineWorker.hpp>
+
+#include <sealtk/core/KwiverPipelinePortSet.hpp>
+#include <sealtk/core/KwiverTrackModel.hpp>
+
+#include <vital/types/detected_object_set.h>
+
+#include <vital/range/valid.h>
+
+#include <qtGet.h>
+#include <qtStlUtil.h>
+
+#include <QRegularExpression>
+
+namespace ka = kwiver::adapter;
+namespace kv = kwiver::vital;
+namespace kvr = kwiver::vital::range;
+
+using ts_time_t = kv::timestamp::time_t;
+
+#define DETECTIONS_PORT "detected_object_set"
+
+using sealtk::core::KwiverTrackModel;
+
+using super = sealtk::core::KwiverPipelineWorker;
+
+namespace sealtk
+{
+
+namespace noaa
+{
+
+namespace core
+{
+
+namespace // anonymous
+{
+
+// ----------------------------------------------------------------------------
+template <typename T> std::weak_ptr<T> weakRef(std::shared_ptr<T> const& p)
+{
+  return p;
+}
+
+// ============================================================================
+class PortSet : sealtk::core::KwiverPipelinePortSet
+{
+public:
+  PortSet(kwiver::embedded_pipeline& pipeline, int index);
+
+  static sprokit::process::ports_t portNames(
+    kwiver::embedded_pipeline& pipeline)
+  {
+    return KwiverPipelinePortSet::portNames(pipeline, PortType::Output);
+  }
+
+  void extractOutput(ka::adapter_data_set_t const& dataSet);
+
+  int index;
+  std::shared_ptr<KwiverTrackModel> model;
+
+private:
+  std::string detectionsPort;
+
+  kv::track_id_t nextTrack = 0;
+};
+
+// ----------------------------------------------------------------------------
+PortSet::PortSet(kwiver::embedded_pipeline& pipeline, int index)
+  : index{index}, model{std::make_shared<KwiverTrackModel>()}
+{
+  this->bind(
+    pipeline, index, PortType::Output,
+    {
+      {this->detectionsPort, this->portName(DETECTIONS_PORT, index)},
+    });
+}
+
+// ----------------------------------------------------------------------------
+void PortSet::extractOutput(ka::adapter_data_set_t const& dataSet)
+{
+  // Get time stamp
+  if (auto* const timeDatum = qtGet(*dataSet, this->timePort))
+  {
+    auto const ts = timeDatum->second->get_datum<kv::timestamp>();
+    auto const t = ts.get_time_usec();
+
+    // Get detections
+    if (auto* const detectionsDatum = qtGet(*dataSet, this->detectionsPort))
+    {
+      auto const& detections =
+        detectionsDatum->second->get_datum<kv::detected_object_set_sptr>();
+
+      if (detections)
+      {
+        auto tracks = std::vector<kv::track_sptr>{};
+
+        // Generate tracks from detections
+        for (auto const& detection : *detections | kvr::valid)
+        {
+          // Create track
+          auto track = kv::track::create();
+          track->set_id(++this->nextTrack);
+
+          // Create object state for track
+          auto state =
+            std::make_shared<kv::object_track_state>(0, t, detection);
+          track->append(state);
+
+          // Add track to set
+          tracks.emplace_back(std::move(track));
+        }
+
+        // Add extracted tracks to model
+        if (!tracks.empty())
+        {
+          auto trackSet = std::make_shared<kv::object_track_set>(tracks);
+          auto&& mwp = weakRef(model);
+
+          QMetaObject::invokeMethod(
+            model.get(),
+            [trackSet = std::move(trackSet), mwp = std::move(mwp)]{
+              if (auto const& model = mwp.lock())
+              {
+                model->addTracks(trackSet);
+              }
+            });
+        }
+      }
+    }
+  }
+}
+
+} // namespace <anonymous>
+
+// ============================================================================
+class NoaaPipelineWorkerPrivate
+{
+public:
+  std::vector<PortSet> outputs;
+};
+
+QTE_IMPLEMENT_D_FUNC(NoaaPipelineWorker)
+
+// ----------------------------------------------------------------------------
+NoaaPipelineWorker::NoaaPipelineWorker(QWidget* parent)
+  : NoaaPipelineWorker{RequiresInput, parent}
+{
+}
+
+// ----------------------------------------------------------------------------
+NoaaPipelineWorker::NoaaPipelineWorker(
+  RequiredEndcaps endcaps, QWidget* parent)
+  : super{endcaps, parent}, d_ptr{new NoaaPipelineWorkerPrivate}
+{
+}
+
+// ----------------------------------------------------------------------------
+NoaaPipelineWorker::~NoaaPipelineWorker()
+{
+}
+
+// ----------------------------------------------------------------------------
+void NoaaPipelineWorker::initializeInput(kwiver::embedded_pipeline& pipeline)
+{
+  QTE_D();
+
+  // Find output ports
+  auto portNameTemplate =
+    QRegularExpression{QStringLiteral(DETECTIONS_PORT "([0-9]+)?")};
+
+  for (auto const& p : PortSet::portNames(pipeline))
+  {
+    auto const& m = portNameTemplate.match(qtString(p));
+    if (m.hasMatch())
+    {
+      auto const& n = m.captured(1);
+      auto const i = (n.isEmpty() ? 0 : n.toInt() - 1);
+
+      d->outputs.emplace_back(pipeline, i);
+    }
+  }
+
+  for (auto const& p : d->outputs)
+  {
+    p.model->moveToThread(this->thread());
+    emit this->trackModelReady(p.index, p.model);
+  }
+
+  this->KwiverPipelineWorker::initializeInput(pipeline);
+}
+
+// ----------------------------------------------------------------------------
+void NoaaPipelineWorker::processOutput(ka::adapter_data_set_t const& output)
+{
+  if (output)
+  {
+    QTE_D();
+
+    for (auto& p : d->outputs)
+    {
+      p.extractOutput(output);
+    }
+  }
+}
+
+} // namespace core
+
+} // namespace noaa
+
+} // namespace kwiver

--- a/sealtk/noaa/core/NoaaPipelineWorker.hpp
+++ b/sealtk/noaa/core/NoaaPipelineWorker.hpp
@@ -1,0 +1,60 @@
+/* This file is part of SEAL-TK, and is distributed under the OSI-approved BSD
+ * 3-Clause License. See top-level LICENSE file or
+ * https://github.com/Kitware/seal-tk/blob/master/LICENSE for details. */
+
+#ifndef sealtk_noaa_core_NoaaPipelineWorker_hpp
+#define sealtk_noaa_core_NoaaPipelineWorker_hpp
+
+#include <sealtk/noaa/core/Export.h>
+
+#include <sealtk/core/KwiverPipelineWorker.hpp>
+
+#include <memory>
+
+class QAbstractItemModel;
+
+namespace sealtk
+{
+
+namespace noaa
+{
+
+namespace core
+{
+
+class NoaaPipelineWorkerPrivate;
+
+// ----------------------------------------------------------------------------
+class SEALTK_NOAA_CORE_EXPORT NoaaPipelineWorker
+  : public sealtk::core::KwiverPipelineWorker
+{
+  Q_OBJECT
+
+public:
+  explicit NoaaPipelineWorker(QWidget* parent = nullptr);
+  explicit NoaaPipelineWorker(RequiredEndcaps, QWidget* parent = nullptr);
+
+  ~NoaaPipelineWorker() override;
+
+signals:
+  void trackModelReady(int index, std::shared_ptr<QAbstractItemModel> model);
+
+protected:
+  QTE_DECLARE_PRIVATE_RPTR(NoaaPipelineWorker);
+
+  void initializeInput(kwiver::embedded_pipeline& pipeline) override;
+
+  void processOutput(
+    kwiver::adapter::adapter_data_set_t const& output) override;
+
+private:
+  QTE_DECLARE_PRIVATE(NoaaPipelineWorker);
+};
+
+} // namespace core
+
+} // namespace noaa
+
+} // namespace sealtk
+
+#endif


### PR DESCRIPTION
Fix several issues with data models and consumers thereof (mostly related to properly handling updates). Create new `NoaaPipelineWorker` class to extract detections from a pipeline, producing a dynamically-updating track model for pipelines which have detection output ports. Modify `noaa::gui::Window` to consume these track models.