### PR TITLE
Fix sorting

### DIFF
--- a/sealtk/core/AbstractProxyModel.cpp
+++ b/sealtk/core/AbstractProxyModel.cpp
@@ -16,6 +16,16 @@ namespace sealtk
 namespace core
 {
 
+namespace // anonymous
+{
+
+// ----------------------------------------------------------------------------
+bool localeAwareLessThan(QString const& left, QString const& right)
+{
+  return QString::localeAwareCompare(left, right) < 0;
+}
+
+} // namespace <anonymous>
 // ----------------------------------------------------------------------------
 bool AbstractProxyModel::isValidData(QVariant const& data, int role)
 {
@@ -58,8 +68,7 @@ bool AbstractProxyModel::lessThan(
     // String comparisons
     case core::NameRole:
     case core::UniqueIdentityRole:
-      return QString::localeAwareCompare(left.toString(),
-                                         right.toString());
+      return localeAwareLessThan(left.toString(), right.toString());
 
     // Boolean comparisons
     case core::VisibilityRole:

--- a/sealtk/gui/AbstractItemRepresentation.cpp
+++ b/sealtk/gui/AbstractItemRepresentation.cpp
@@ -327,40 +327,6 @@ bool AbstractItemRepresentation::filterAcceptsColumn(
     sourceColumn, sourceParent);
 }
 
-// ----------------------------------------------------------------------------
-void AbstractItemRepresentation::sort(int column, Qt::SortOrder order)
-{
-  QTE_D();
-
-  this->AbstractProxyModel::sort(column, order);
-
-  // Determine, if we are sorting (column >= 0), if QSortFilterProxyModel
-  // figured out what column to sort; if not, we may need to force a sort later
-  d->sortNeeded =
-    column >= 0 && !this->mapToSource(this->index(0, column, {})).isValid();
-}
-
-// ----------------------------------------------------------------------------
-void AbstractItemRepresentation::updateSort()
-{
-  QTE_D();
-
-  // Our data has changed; if we previously failed to sort...
-  if (d->sortNeeded)
-  {
-    // ...then attempt to do so now (if dynamic sorting is enabled)
-    if (this->dynamicSortFilter())
-    {
-      // NOTE: Must clear dynamic sort filter first or sort() will decline to
-      //       actually do anything; this ends up sorting twice, but there
-      //       doesn't seem to be any way around that
-      this->setDynamicSortFilter(false);
-      this->sort(this->sortColumn(), this->sortOrder());
-      this->setDynamicSortFilter(true);
-    }
-  }
-}
-
 } // namespace gui
 
 } // namespace sealtk

--- a/sealtk/gui/AbstractItemRepresentation.hpp
+++ b/sealtk/gui/AbstractItemRepresentation.hpp
@@ -83,25 +83,10 @@ public:
   QVariant headerData(int section, Qt::Orientation orientation,
                       int role = Qt::DisplayRole) const override;
 
-  // Reimplemented from QSortFilterProxyModel
-  void sort(int column, Qt::SortOrder order = Qt::AscendingOrder) override;
-
 public slots:
   /// Set the visibility mode for "hidden" items.
   /// \sa ItemVisibilityMode, itemVisibilityMode, itemVisibilityMode()
   virtual void setItemVisibilityMode(ItemVisibilityMode);
-
-protected slots:
-  /// Update sorting when data changes.
-  ///
-  /// This slot checks if the model has not been sorted, and if so, sorts it.
-  /// This is done to work around a bug in QSortFilterProxyModel where items
-  /// are not sorted after a data change if all items were initially hidden.
-  ///
-  /// This slot is called automatically when the proxy model's data changes
-  /// (note: \em not the source model's data). Users should not normally need
-  /// to call this slot themselves.
-  void updateSort();
 
 protected:
   QTE_DECLARE_PRIVATE_RPTR(AbstractItemRepresentation)

--- a/sealtk/noaa/gui/Window.ui
+++ b/sealtk/noaa/gui/Window.ui
@@ -73,7 +73,17 @@
    <widget class="QWidget" name="trackDockContents">
     <layout class="QVBoxLayout" name="verticalLayout_2">
      <item>
-      <widget class="QTreeView" name="tracks"/>
+      <widget class="QTreeView" name="tracks">
+       <property name="alternatingRowColors">
+        <bool>true</bool>
+       </property>
+       <property name="sortingEnabled">
+        <bool>true</bool>
+       </property>
+       <property name="allColumnsShowFocus">
+        <bool>true</bool>
+       </property>
+      </widget>
      </item>
     </layout>
    </widget>


### PR DESCRIPTION
Fix a bug in the implementation of `AbstractProxyModel::lessThan` which was not returning the correct result when comparing strings. Ensure that the "detections" list in the NOAA GUI can be sorted by the user. Remove some code in AbstractItemRepresentation left over from when the class was more-or-less imported from [ViViA](https://github.com/kitware/vivia) to work around a Qt bug that seems to have been squashed, and is therefore no longer needed.