### PR TITLE
Change default detection color

### DIFF
--- a/sealtk/noaa/gui/Window.cpp
+++ b/sealtk/noaa/gui/Window.cpp
@@ -383,6 +383,7 @@ void WindowPrivate::createWindow(WindowData* data, QString const& title,
   data->window->setCentralWidget(data->player);
   data->window->setClosable(false);
   data->window->setWindowTitle(title);
+  data->player->setDefaultColor(qRgb(240, 176, 48));
 
   QObject::connect(q, &Window::zoomChanged,
                    data->player, &sg::Player::setZoom);


### PR DESCRIPTION
Use a bright orange instead of yellow as the default color for detections. This will hopefully have slightly improved contrast for our NOAA imagery which often has a lot of light gray and white.