### PR TITLE
Allow "editing" track types

### DIFF
--- a/sealtk/gui/FusionModel.cpp
+++ b/sealtk/gui/FusionModel.cpp
@@ -260,6 +260,7 @@ bool FusionModel::setData(
     auto const& r = d->data[index.row()];
     switch (role)
     {
+      case core::ClassificationRole:
       case core::UserVisibilityRole:
         return d->setData(r, value, role);
 

--- a/sealtk/noaa/gui/CMakeLists.txt
+++ b/sealtk/noaa/gui/CMakeLists.txt
@@ -9,6 +9,7 @@ sealtk_add_library(sealtk::noaa_gui
     About.cpp
     Player.cpp
     Resources.cpp
+    TrackTypeDelegate.cpp
     Window.cpp
     SEALTKBranding.qrc
 
@@ -16,6 +17,7 @@ sealtk_add_library(sealtk::noaa_gui
     About.hpp
     Player.hpp
     Resources.hpp
+    TrackTypeDelegate.hpp
     Window.hpp
 
   PUBLIC_LINK_LIBRARIES

--- a/sealtk/noaa/gui/TrackTypeDelegate.cpp
+++ b/sealtk/noaa/gui/TrackTypeDelegate.cpp
@@ -1,0 +1,98 @@
+/* This file is part of SEAL-TK, and is distributed under the OSI-approved BSD
+ * 3-Clause License. See top-level LICENSE file or
+ * https://github.com/Kitware/seal-tk/blob/master/LICENSE for details. */
+
+#include <sealtk/noaa/gui/TrackTypeDelegate.hpp>
+
+#include <sealtk/core/DataModelTypes.hpp>
+
+#include <vital/types/detected_object_type.h>
+
+#include <vital/range/iota.h>
+
+#include <qtStlUtil.h>
+
+#include <QComboBox>
+
+namespace kv = kwiver::vital;
+namespace kvr = kwiver::vital::range;
+
+namespace sealtk
+{
+
+namespace noaa
+{
+
+namespace gui
+{
+
+// ----------------------------------------------------------------------------
+TrackTypeDelegate::TrackTypeDelegate(QObject* parent)
+  : QStyledItemDelegate{parent}
+{
+}
+
+// ----------------------------------------------------------------------------
+TrackTypeDelegate::~TrackTypeDelegate()
+{
+}
+
+// ----------------------------------------------------------------------------
+QWidget* TrackTypeDelegate::createEditor(
+  QWidget* parent, QStyleOptionViewItem const& option,
+  QModelIndex const& index) const
+{
+  QComboBox* box = new QComboBox{parent};
+  box->setEditable(true);
+  box->setFocusPolicy(Qt::StrongFocus);
+  box->setFrame(false);
+
+  for (auto const& type : kv::detected_object_type::all_class_names())
+  {
+    box->addItem(qtString(type));
+  }
+
+  return box;
+}
+
+// ----------------------------------------------------------------------------
+void TrackTypeDelegate::setEditorData(
+  QWidget* editor, QModelIndex const& index) const
+{
+  if (auto* const model = index.model())
+  {
+    auto const& data = model->data(index, core::ClassificationTypeRole);
+    auto const& type = data.toString();
+
+    auto* const box = qobject_cast<QComboBox*>(editor);
+
+    int i = -1;
+    for (auto const j : kvr::iota(box->count()))
+    {
+      if (box->itemText(j) == type)
+      {
+        i = j;
+        break;
+      }
+    }
+
+    box->setCurrentIndex(i);
+  }
+}
+
+// ----------------------------------------------------------------------------
+void TrackTypeDelegate::setModelData(
+  QWidget* editor, QAbstractItemModel* model, QModelIndex const& index) const
+{
+  auto* const box = qobject_cast<QComboBox*>(editor);
+  auto const& newType = box->currentText();
+
+  auto newClassification = QVariantHash{{newType, 1.0}};
+  model->setData(index, newClassification, core::ClassificationRole);
+}
+
+} // namespace gui
+
+} // namespace noaa
+
+} // namespace sealtk

--- a/sealtk/noaa/gui/TrackTypeDelegate.hpp
+++ b/sealtk/noaa/gui/TrackTypeDelegate.hpp
@@ -1,0 +1,45 @@
+/* This file is part of SEAL-TK, and is distributed under the OSI-approved BSD
+ * 3-Clause License. See top-level LICENSE file or
+ * https://github.com/Kitware/seal-tk/blob/master/LICENSE for details. */
+
+#ifndef sealtk_noaa_gui_TrackTypeDelegate_hpp
+#define sealtk_noaa_gui_TrackTypeDelegate_hpp
+
+#include <sealtk/noaa/gui/Export.h>
+
+#include <QStyledItemDelegate>
+
+namespace sealtk
+{
+
+namespace noaa
+{
+
+namespace gui
+{
+
+class SEALTK_NOAA_GUI_EXPORT TrackTypeDelegate : public QStyledItemDelegate
+{
+  Q_OBJECT
+
+public:
+  explicit TrackTypeDelegate(QObject* parent = nullptr);
+  ~TrackTypeDelegate() override;
+
+  QWidget* createEditor(
+    QWidget* parent, QStyleOptionViewItem const& option,
+    QModelIndex const& index) const override;
+  void setEditorData(
+    QWidget* editor, QModelIndex const& index) const override;
+  void setModelData(
+    QWidget* editor, QAbstractItemModel* model,
+    QModelIndex const& index) const override;
+};
+
+} // namespace gui
+
+} // namespace noaa
+
+} // namespace sealtk
+
+#endif

--- a/sealtk/noaa/gui/Window.cpp
+++ b/sealtk/noaa/gui/Window.cpp
@@ -7,6 +7,7 @@
 
 #include <sealtk/noaa/gui/About.hpp>
 #include <sealtk/noaa/gui/Player.hpp>
+#include <sealtk/noaa/gui/TrackTypeDelegate.hpp>
 
 #include <sealtk/noaa/core/ImageListVideoSourceFactory.hpp>
 #include <sealtk/noaa/core/NoaaPipelineWorker.hpp>
@@ -83,6 +84,19 @@ public:
     this->setItemVisibilityMode(sg::OmitHidden);
   }
 
+  Qt::ItemFlags flags(QModelIndex const& index) const override
+  {
+    auto const defaultFlags =
+      this->sg::AbstractItemRepresentation::flags(index);
+
+    if (index.column() == 2)
+    {
+      return defaultFlags | Qt::ItemIsEditable;
+    }
+
+    return defaultFlags;
+  }
+
   QVariant headerData(int section, Qt::Orientation orientation,
                       int role = Qt::DisplayRole) const override
   {
@@ -133,6 +147,7 @@ public:
 
   sg::FusionModel trackModel;
   TrackRepresentation trackRepresentation;
+  TrackTypeDelegate typeDelegate;
 
   std::unique_ptr<sc::VideoController> videoController;
 
@@ -160,6 +175,7 @@ Window::Window(QWidget* parent)
 
   d->trackRepresentation.setSourceModel(&d->trackModel);
   d->ui.tracks->setModel(&d->trackRepresentation);
+  d->ui.tracks->setItemDelegateForColumn(2, &d->typeDelegate);
 
   constexpr auto Master = sealtk::noaa::gui::Player::Role::Master;
   constexpr auto Slave = sealtk::noaa::gui::Player::Role::Slave;


### PR DESCRIPTION
Hook up ability to change the type of a "detection" (i.e. track) in the NOAA GUI. This is a very rough-and-ready implementation, but for now it should be functional.