### PR TITLE
Fix some minor aesthetic issues

### DIFF
--- a/sealtk/gui/AbstractItemRepresentation.cpp
+++ b/sealtk/gui/AbstractItemRepresentation.cpp
@@ -240,7 +240,7 @@ QVariant AbstractItemRepresentation::data(
       switch (dataRole)
       {
         case core::ClassificationScoreRole:
-          return Qt::AlignRight;
+          return static_cast<int>(Qt::AlignRight | Qt::AlignVCenter);
 
         default:
           break;

--- a/sealtk/noaa/gui/Window.ui
+++ b/sealtk/noaa/gui/Window.ui
@@ -78,6 +78,9 @@
        <property name="alternatingRowColors">
         <bool>true</bool>
        </property>
+       <property name="rootIsDecorated">
+        <bool>false</bool>
+       </property>
        <property name="sortingEnabled">
         <bool>true</bool>
        </property>


### PR DESCRIPTION
Remove root decoration in NOAA track list; at least for now, it serves no purpose. Fix text alignment of classification score.