### PR TITLE
Add ability to hide IR pane in NOAA GUI

### DIFF
--- a/sealtk/noaa/gui/Window.cpp
+++ b/sealtk/noaa/gui/Window.cpp
@@ -174,6 +174,9 @@ Window::Window(QWidget* parent)
   connect(d->eoWindow.player, &sg::Player::imageSizeChanged,
           d->irWindow.player, &sg::Player::setHomographyImageSize);
 
+  connect(d->ui.actionShowIrPane, &QAction::toggled,
+          d->irWindow.window, &QWidget::setVisible);
+
   d->videoController = make_unique<sc::VideoController>(this);
   d->ui.control->setVideoController(d->videoController.get());
 
@@ -238,6 +241,7 @@ Window::Window(QWidget* parent)
   d->uiState.mapGeometry("Window/geometry", this);
   d->uiState.mapState("Window/splitter", d->ui.centralwidget);
   d->uiState.mapState("Tracks/state", d->ui.tracks->header());
+  d->uiState.mapChecked("View/showIR", d->ui.actionShowIrPane);
 
   d->uiState.restore();
 }

--- a/sealtk/noaa/gui/Window.ui
+++ b/sealtk/noaa/gui/Window.ui
@@ -61,7 +61,14 @@
     <addaction name="menuPipeline"/>
     <addaction name="actionDeleteDetection"/>
    </widget>
+   <widget class="QMenu" name="menuView">
+    <property name="title">
+     <string>&amp;View</string>
+    </property>
+    <addaction name="actionShowIrPane"/>
+   </widget>
    <addaction name="menuTools"/>
+   <addaction name="menuView"/>
    <addaction name="menuHelp"/>
   </widget>
   <widget class="QDockWidget" name="trackDock">
@@ -106,6 +113,17 @@
    </property>
    <property name="shortcut">
     <string>Del</string>
+   </property>
+  </action>
+  <action name="actionShowIrPane">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="checked">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>&amp;IR Pane</string>
    </property>
   </action>
  </widget>


### PR DESCRIPTION
Add a View menu to the NOAA GUI, with the (persisted) ability to toggle whether or not the IR pane is visible.