### PR TITLE
Little fixes

### DIFF
--- a/sealtk/core/AbstractItemModel.cpp
+++ b/sealtk/core/AbstractItemModel.cpp
@@ -6,6 +6,8 @@
 
 #include <sealtk/core/DataModelTypes.hpp>
 
+#include <algorithm>
+
 namespace sealtk
 {
 
@@ -70,7 +72,7 @@ QVariant AbstractItemModel::data(QModelIndex const& index, int role) const
 void AbstractItemModel::emitDataChanged(
   QModelIndex const& parent, QList<int>&& rows, QVector<int> const& roles)
 {
-  qSort(rows.begin(), rows.end());
+  std::sort(rows.begin(), rows.end());
 
   auto first = rows.takeFirst();
   auto last = first;

--- a/sealtk/core/KwiverTrackModel.cpp
+++ b/sealtk/core/KwiverTrackModel.cpp
@@ -340,6 +340,7 @@ bool KwiverTrackModel::setData(
           auto const& canonicalIndex = this->createIndex(index.row(), 0);
           emit this->dataChanged(canonicalIndex, canonicalIndex, {role});
         }
+        break;
 
       case core::UserVisibilityRole:
         if (value.canConvert<bool>())
@@ -350,6 +351,7 @@ bool KwiverTrackModel::setData(
           emit this->dataChanged(canonicalIndex, canonicalIndex,
                                  {role, core::VisibilityRole});
         }
+        break;
 
       default:
         break;


### PR DESCRIPTION
Use `std::sort` instead of `qSort` per deprecation warning. Add missing `break`s in `switch` (fixes a fall-through warning, might fix bugs).