### PR TITLE
Remove gratuitous smart pointer

### DIFF
--- a/sealtk/noaa/gui/Window.cpp
+++ b/sealtk/noaa/gui/Window.cpp
@@ -149,7 +149,7 @@ public:
   TrackRepresentation trackRepresentation;
   TrackTypeDelegate typeDelegate;
 
-  std::unique_ptr<sc::VideoController> videoController;
+  sc::VideoController* videoController;
 
   WindowData eoWindow;
   WindowData irWindow;
@@ -209,8 +209,8 @@ Window::Window(QWidget* parent)
   connect(d->ui.actionShowUvPane, &QAction::toggled,
           d->uvWindow.window, &QWidget::setVisible);
 
-  d->videoController = make_unique<sc::VideoController>(this);
-  d->ui.control->setVideoController(d->videoController.get());
+  d->videoController = new sc::VideoController{this};
+  d->ui.control->setVideoController(d->videoController);
 
   connect(d->ui.actionAbout, &QAction::triggered,
           this, &Window::showAbout);
@@ -264,10 +264,10 @@ Window::Window(QWidget* parent)
 
   d->registerVideoSourceFactory(
     QStringLiteral("Image List File..."),
-    new core::ImageListVideoSourceFactory{false, d->videoController.get()});
+    new core::ImageListVideoSourceFactory{false, d->videoController});
   d->registerVideoSourceFactory(
     QStringLiteral("Image Directory..."),
-    new core::ImageListVideoSourceFactory{true, d->videoController.get()});
+    new core::ImageListVideoSourceFactory{true, d->videoController});
 
   d->uiState.mapState("Window/state", this);
   d->uiState.mapGeometry("Window/geometry", this);


### PR DESCRIPTION
Don't use a `std::unique_ptr` to store the `VideoController`. This is a `QObject` that is already managed by the `QObject` hierarchy, and will be cleaned up via the same. (We are somewhat fortunate, in fact, that the smart pointer was deleting it before the parent tries to reap children, or we would be seeing a double free. While we can *probably* rely on this, the smart pointer isn't necessary, and just using the `QObject` hierarchy simplifies things slightly.)