### PR TITLE
"Require" C++14

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,7 +34,7 @@ find_package(Threads REQUIRED)
 find_package(Git)
 find_package(Sphinx)
 
-set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED TRUE)
 set(CMAKE_CXX_VISIBILITY_PRESET hidden)
 set(CMAKE_AUTOMOC 1)

--- a/cmake/SEALTKUtils.cmake
+++ b/cmake/SEALTKUtils.cmake
@@ -51,10 +51,6 @@ function(sealtk_add_library name)
   if (sal_TYPE STREQUAL INTERFACE)
     add_library(${suffix} INTERFACE)
 
-    target_compile_features(${suffix}
-      INTERFACE cxx_lambda_init_captures
-      )
-
     target_link_libraries(${suffix}
       INTERFACE ${sal_PUBLIC_LINK_LIBRARIES}
       )
@@ -73,10 +69,6 @@ function(sealtk_add_library name)
       LIBRARY_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/${CMAKE_INSTALL_LIBDIR}"
       ARCHIVE_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/${CMAKE_INSTALL_LIBDIR}"
       OUTPUT_NAME "sealtk_${suffix}"
-      )
-
-    target_compile_features(${suffix}
-      PUBLIC cxx_lambda_init_captures
       )
 
     target_link_libraries(${suffix}


### PR DESCRIPTION
Modify CMake code to request full C++14. Apparently this does work with GCC 4.8.x, even though that was some ways from full C++14 support, whereas requesting C++11 plus the required additional features does not. While there was a plan to fix this at one point, apparently it is not going to happen, and this is the "sanctioned" way to use C++1y with GCC 4.8.