### PR TITLE
Make NOAA GUI plugins configurable

### DIFF
--- a/sealtk/noaa/CMakeLists.txt
+++ b/sealtk/noaa/CMakeLists.txt
@@ -8,6 +8,21 @@ add_subdirectory(core)
 add_subdirectory(gui)
 add_subdirectory(kwiver)
 
+set(NOAA_TRACK_READER "kw18" CACHE STRING
+    "Name of KWIVER plugin used by the NOAA GUI to read tracks")
+set(NOAA_TRACK_WRITER "kw18" CACHE STRING
+    "Name of KWIVER plugin used by the NOAA GUI to write tracks")
+set(NOAA_VIDEO_READER "noaa_timestamp_passthrough" CACHE STRING
+    "Name of KWIVER plugin used by the NOAA GUI to read video")
+set(NOAA_VIDEO_READER_PASSTHROUGH "vxl" CACHE STRING
+    "Name of pass-through KWIVER plugin used by the NOAA GUI to read video")
+
+configure_file(
+  ${CMAKE_CURRENT_SOURCE_DIR}/PluginConfig.hpp.in
+  ${CMAKE_CURRENT_BINARY_DIR}/PluginConfig.hpp
+  @ONLY
+  )
+
 sealtk_add_executable(sealtk::noaa_app
   SOURCES
     Main.cpp

--- a/sealtk/noaa/PluginConfig.hpp.in
+++ b/sealtk/noaa/PluginConfig.hpp.in
@@ -1,0 +1,26 @@
+/* This file is part of SEAL-TK, and is distributed under the OSI-approved BSD
+ * 3-Clause License. See top-level LICENSE file or
+ * https://github.com/Kitware/seal-tk/blob/master/LICENSE for details. */
+
+#include <QString>
+
+namespace sealtk
+{
+
+namespace noaa
+{
+
+namespace config
+{
+
+auto const trackReader = QStringLiteral("@NOAA_TRACK_READER@");
+auto const trackWriter = QStringLiteral("@NOAA_TRACK_WRITER@");
+
+constexpr auto videoReader = "@NOAA_VIDEO_READER@";
+constexpr auto videoReaderPassthrough = "@NOAA_VIDEO_READER_PASSTHROUGH@";
+
+} // namespace config
+
+} // namespace noaa
+
+} // namespace sealtk

--- a/sealtk/noaa/core/ImageListVideoSourceFactory.cpp
+++ b/sealtk/noaa/core/ImageListVideoSourceFactory.cpp
@@ -4,6 +4,8 @@
 
 #include <sealtk/noaa/core/ImageListVideoSourceFactory.hpp>
 
+#include <sealtk/noaa/PluginConfig.hpp>
+
 namespace sealtk
 {
 
@@ -52,9 +54,13 @@ kwiver::vital::config_block_sptr ImageListVideoSourceFactory::config(
   auto config = kwiver::vital::config_block::empty_config();
   config->set_value("video_reader:type", "image_list");
   config->set_value("video_reader:image_list:image_reader:type",
-                    "noaa_timestamp_passthrough");
-  config->set_value("video_reader:image_list:image_reader:"
-                    "noaa_timestamp_passthrough:image_reader:type", "vxl");
+                    config::videoReader);
+  if (*config::videoReaderPassthrough)
+  {
+    auto key = std::string{"video_reader:image_list:image_reader:"} +
+               config::videoReader + ":image_reader:type";
+    config->set_value(key, config::videoReaderPassthrough);
+  }
 
   return config;
 }

--- a/sealtk/noaa/gui/Window.cpp
+++ b/sealtk/noaa/gui/Window.cpp
@@ -12,6 +12,8 @@
 #include <sealtk/noaa/core/ImageListVideoSourceFactory.hpp>
 #include <sealtk/noaa/core/NoaaPipelineWorker.hpp>
 
+#include <sealtk/noaa/PluginConfig.hpp>
+
 #include <sealtk/gui/AbstractItemRepresentation.hpp>
 #include <sealtk/gui/FusionModel.hpp>
 
@@ -461,7 +463,7 @@ void WindowPrivate::loadDetections(WindowData* data)
     auto uri = QUrl::fromLocalFile(filename);
     auto params = QUrlQuery{};
 
-    params.addQueryItem("input:type", "kw18");
+    params.addQueryItem("input:type", config::trackReader);
     uri.setQuery(params);
 
     data->trackSource =
@@ -509,7 +511,7 @@ void WindowPrivate::saveDetections(WindowData* data)
       auto uri = QUrl::fromLocalFile(filename);
       auto params = QUrlQuery{};
 
-      params.addQueryItem("output:type", "kw18");
+      params.addQueryItem("output:type", config::trackWriter);
       uri.setQuery(params);
 
       QObject::connect(


### PR DESCRIPTION
An ongoing issue has been that we expect the NOAA GUI to be built to use KWIVER plugins from an additional dependency (VIAME), but don't want this dependency to be mandatory. As a result, we have been maintaining a branch that changes some of the plugins used.

Instead, arrange for the ability to configure the relevant plugin selection at configure time. This maintains our goal of minimizing dependencies out-of-the-box, but will make it possible to punt plugin selection to configure time, rather than having to maintain a branch to change the defaults.