### PR TITLE
Sort video frames by time

### DIFF
--- a/sealtk/noaa/core/ImageListVideoSourceFactory.cpp
+++ b/sealtk/noaa/core/ImageListVideoSourceFactory.cpp
@@ -53,6 +53,7 @@ kwiver::vital::config_block_sptr ImageListVideoSourceFactory::config(
 {
   auto config = kwiver::vital::config_block::empty_config();
   config->set_value("video_reader:type", "image_list");
+  config->set_value("video_reader:image_list:sort_by_time", "true");
   config->set_value("video_reader:image_list:image_reader:type",
                     config::videoReader);
   if (*config::videoReaderPassthrough)


### PR DESCRIPTION
Enable the option to tell `video_input_image_list` to sort the set of frames according to their timestamps. This will alter their frame numbers and may prevent some potential issues that could arise particularly with pipelines because we generally process things in temporal order and expect that to match frame order. (In particular, there are some places that we expect things to arrive in temporal order that try to append to KWIVER `track`s, which will fail if the frame number order does not match the temporal order.)

Note that this "depends" on Kitware/kwiver#1007, which adds the aforementioned functionality to KWIVER. Things will still run without that, but this change won't do anything.