### PR TITLE
Don't use deprecated algorithm class

### DIFF
--- a/sealtk/noaa/kwiver/TimestampPassthrough.hpp
+++ b/sealtk/noaa/kwiver/TimestampPassthrough.hpp
@@ -19,8 +19,7 @@ namespace kwiver
 {
 
 class SEALTK_NOAA_KWIVER_EXPORT TimestampPassthrough
-  : public ::kwiver::vital::algorithm_impl<TimestampPassthrough,
-                                           ::kwiver::vital::algo::image_io>
+  : public ::kwiver::vital::algo::image_io
 {
 public:
   TimestampPassthrough();


### PR DESCRIPTION
Don't use the now-deprecated `algorithm_impl` wrapper class for our `TimestampPassthrough` algorithm.

See also Kitware/kwiver#757.

@linus-sherrill, can you also please verify that this is the intended fix?