### PR TITLE
Fix a seek issue that can cause 'lost' frames

### DIFF
--- a/sealtk/core/VideoSource.cpp
+++ b/sealtk/core/VideoSource.cpp
@@ -207,6 +207,7 @@ void VideoSourcePrivate::dispatchFrameRequests()
     {
       auto dummyFrame = VideoFrame{nullptr, VideoMetaData{}};
       request.second.sendReply(std::move(dummyFrame));
+      this->lastFrameProvided[request.first] = {};
     }
   }
   this->requests.clear();


### PR DESCRIPTION
Fix a bug in the frame request logic where, if we issue a successful request for a frame at `X`, followed by a request for `Y` which does not have a frame, and then request `X` again, the underlying source thinks that it has already issued the frame, while the generic source has sent the requester an empty frame. This would result in the requester (i.e. the GUI) being incorrectly issued an empty frame for the second request of `X`.