### PR TITLE
Make classification scores "editable"

### DIFF
--- a/sealtk/noaa/gui/CMakeLists.txt
+++ b/sealtk/noaa/gui/CMakeLists.txt
@@ -10,6 +10,7 @@ sealtk_add_library(sealtk::noaa_gui
     NotesDelegate.cpp
     Player.cpp
     Resources.cpp
+    TrackScoreDelegate.cpp
     TrackTypeDelegate.cpp
     Window.cpp
     SEALTKBranding.qrc
@@ -19,6 +20,7 @@ sealtk_add_library(sealtk::noaa_gui
     NotesDelegate.hpp
     Player.hpp
     Resources.hpp
+    TrackScoreDelegate.hpp
     TrackTypeDelegate.hpp
     Window.hpp
 

--- a/sealtk/noaa/gui/TrackScoreDelegate.cpp
+++ b/sealtk/noaa/gui/TrackScoreDelegate.cpp
@@ -1,0 +1,63 @@
+/* This file is part of SEAL-TK, and is distributed under the OSI-approved BSD
+ * 3-Clause License. See top-level LICENSE file or
+ * https://github.com/Kitware/seal-tk/blob/master/LICENSE for details. */
+
+#include <sealtk/noaa/gui/TrackScoreDelegate.hpp>
+
+#include <sealtk/core/DataModelTypes.hpp>
+
+#include <QDoubleSpinBox>
+
+namespace sealtk
+{
+
+namespace noaa
+{
+
+namespace gui
+{
+
+// ----------------------------------------------------------------------------
+TrackScoreDelegate::TrackScoreDelegate(QObject* parent)
+  : qtDoubleSpinBoxDelegate{parent}
+{
+  this->setRange(0.0, 1.0);
+  this->setPrecision(5);
+}
+
+// ----------------------------------------------------------------------------
+TrackScoreDelegate::~TrackScoreDelegate()
+{
+}
+
+// ----------------------------------------------------------------------------
+void TrackScoreDelegate::setEditorData(
+  QWidget* editor, QModelIndex const& index) const
+{
+  if (auto* const model = index.model())
+  {
+    auto const& data = model->data(index, core::ClassificationScoreRole);
+    auto* const spin = qobject_cast<QDoubleSpinBox*>(editor);
+    spin->setValue(data.toDouble());
+  }
+}
+
+// ----------------------------------------------------------------------------
+void TrackScoreDelegate::setModelData(
+  QWidget* editor, QAbstractItemModel* model, QModelIndex const& index) const
+{
+  QDoubleSpinBox* spin = qobject_cast<QDoubleSpinBox*>(editor);
+  spin->interpretText();
+
+  auto const& typeData = model->data(index, core::ClassificationTypeRole);
+  auto const& newScore = spin->value();
+
+  auto newClassification = QVariantHash{{typeData.toString(), newScore}};
+  model->setData(index, newClassification, core::ClassificationRole);
+}
+
+} // namespace gui
+
+} // namespace noaa
+
+} // namespace sealtk

--- a/sealtk/noaa/gui/TrackScoreDelegate.hpp
+++ b/sealtk/noaa/gui/TrackScoreDelegate.hpp
@@ -1,0 +1,43 @@
+/* This file is part of SEAL-TK, and is distributed under the OSI-approved BSD
+ * 3-Clause License. See top-level LICENSE file or
+ * https://github.com/Kitware/seal-tk/blob/master/LICENSE for details. */
+
+#ifndef sealtk_noaa_gui_TrackScoreDelegate_hpp
+#define sealtk_noaa_gui_TrackScoreDelegate_hpp
+
+#include <sealtk/noaa/gui/Export.h>
+
+#include <qtDoubleSpinBoxDelegate.h>
+
+namespace sealtk
+{
+
+namespace noaa
+{
+
+namespace gui
+{
+
+class SEALTK_NOAA_GUI_EXPORT TrackScoreDelegate
+  : public qtDoubleSpinBoxDelegate
+{
+  Q_OBJECT
+
+public:
+  explicit TrackScoreDelegate(QObject* parent = nullptr);
+  ~TrackScoreDelegate() override;
+
+  void setEditorData(
+    QWidget* editor, QModelIndex const& index) const override;
+  void setModelData(
+    QWidget* editor, QAbstractItemModel* model,
+    QModelIndex const& index) const override;
+};
+
+} // namespace gui
+
+} // namespace noaa
+
+} // namespace sealtk
+
+#endif

--- a/sealtk/noaa/gui/Window.cpp
+++ b/sealtk/noaa/gui/Window.cpp
@@ -8,6 +8,7 @@
 #include <sealtk/noaa/gui/About.hpp>
 #include <sealtk/noaa/gui/NotesDelegate.hpp>
 #include <sealtk/noaa/gui/Player.hpp>
+#include <sealtk/noaa/gui/TrackScoreDelegate.hpp>
 #include <sealtk/noaa/gui/TrackTypeDelegate.hpp>
 
 #include <sealtk/noaa/core/ImageListVideoSourceFactory.hpp>
@@ -119,12 +120,26 @@ public:
     auto const defaultFlags =
       this->sg::AbstractItemRepresentation::flags(index);
 
-    if (index.column() == 3 || index.column() == 5)
+    switch (index.column())
     {
-      return defaultFlags | Qt::ItemIsEditable;
-    }
+      case 3: // Type
+      case 5: // Notes
+        return defaultFlags | Qt::ItemIsEditable;
 
-    return defaultFlags;
+      case 4: // Score
+      {
+        auto const& data =
+          index.model()->data(index, sc::ClassificationRole);
+        if (!data.toHash().isEmpty())
+        {
+          return defaultFlags | Qt::ItemIsEditable;
+        }
+        return defaultFlags;
+      }
+
+      default:
+        return defaultFlags;
+    }
   }
 };
 
@@ -187,6 +202,7 @@ public:
   sc::ScalarFilterModel trackModelFilter;
   TrackRepresentation trackRepresentation;
   TrackTypeDelegate typeDelegate;
+  TrackScoreDelegate scoreDelegate;
   NotesDelegate notesDelegate;
 
   sg::ClassificationSummaryRepresentation statisticsRepresentation;
@@ -258,6 +274,7 @@ Window::Window(QWidget* parent)
   d->trackRepresentation.setSourceModel(&d->trackModelFilter);
   d->ui.tracks->setModel(&d->trackRepresentation);
   d->ui.tracks->setItemDelegateForColumn(3, &d->typeDelegate);
+  d->ui.tracks->setItemDelegateForColumn(4, &d->scoreDelegate);
   d->ui.tracks->setItemDelegateForColumn(5, &d->notesDelegate);
 
   connect(d->scoreFilter, &sg::FilterWidget::filterMinimumChanged,


### PR DESCRIPTION
Add ability to edit classification scores. Similar to setting the type, doing so will nuke any other classifiers other that might be present.