### PR TITLE
Allow toggling automatic contrast

### DIFF
--- a/sealtk/gui/Player.cpp
+++ b/sealtk/gui/Player.cpp
@@ -584,6 +584,7 @@ void Player::setContrastMode(ContrastMode newMode)
   if (d->contrastMode != newMode)
   {
     d->contrastMode = newMode;
+    emit this->contrastModeChanged(newMode);
     this->update();
   }
 }

--- a/sealtk/gui/Player.hpp
+++ b/sealtk/gui/Player.hpp
@@ -41,6 +41,11 @@ QTE_ENUM_NS(ContrastMode)
 
 QTE_END_META_NAMESPACE()
 
+#if defined(_MSC_VER) && _MSC_VER < 1920
+// Work around name lookup bug in MSVC < 19.20
+using player_enums::ContrastMode;
+#endif
+
 class PlayerTool;
 
 class PlayerPrivate;

--- a/sealtk/gui/Player.hpp
+++ b/sealtk/gui/Player.hpp
@@ -54,7 +54,10 @@ class SEALTK_GUI_EXPORT Player : public QOpenGLWidget
   Q_PROPERTY(QSize homographyImageSize
              READ homographyImageSize
              WRITE setHomographyImageSize)
-  Q_PROPERTY(ContrastMode contrastMode READ contrastMode WRITE setContrastMode)
+  Q_PROPERTY(ContrastMode contrastMode
+             READ contrastMode
+             WRITE setContrastMode
+             NOTIFY contrastModeChanged)
   Q_PROPERTY(QMatrix4x4 homography READ homography WRITE setHomography)
   Q_PROPERTY(QMatrix4x4 viewHomography READ viewHomography)
 
@@ -92,6 +95,8 @@ signals:
   void imageSizeChanged(QSize imageSize) const;
   void imageNameChanged(QString const& imageName) const;
   void activeToolChanged(PlayerTool* tool) const;
+
+  void contrastModeChanged(ContrastMode mode) const;
 
   void defaultColorChanged(QColor const& color) const;
   void selectionColorChanged(QColor const& color) const;

--- a/sealtk/noaa/gui/Player.cpp
+++ b/sealtk/noaa/gui/Player.cpp
@@ -47,6 +47,7 @@ public:
 
   QAction* loadTransformAction = nullptr;
   QAction* resetTransformAction = nullptr;
+  QAction* toggleAutoLevelsAction = nullptr;
   QAction* loadDetectionsAction = nullptr;
   QAction* saveDetectionsAction = nullptr;
   QAction* mergeDetectionsAction = nullptr;
@@ -96,6 +97,29 @@ Player::Player(Role role, QWidget* parent)
     d->contextMenu->addAction(d->resetTransformAction);
   }
 
+  d->toggleAutoLevelsAction = new QAction{"&Automatic Levels", this};
+  d->toggleAutoLevelsAction->setCheckable(true);
+  d->toggleAutoLevelsAction->setChecked(
+    this->contrastMode() == sealtk::gui::ContrastMode::Percentile);
+
+  connect(
+    d->toggleAutoLevelsAction, &QAction::toggled, this,
+    [this](bool checked){
+      auto const mode = (checked
+                         ? sealtk::gui::ContrastMode::Percentile
+                         : sealtk::gui::ContrastMode::Manual);
+      this->setContrastMode(mode);
+    });
+  connect(
+    this, &Player::contrastModeChanged, this,
+    [d](sealtk::gui::ContrastMode mode)
+    {
+      d->toggleAutoLevelsAction->setChecked(
+        mode == sealtk::gui::ContrastMode::Percentile);
+    });
+
+  d->contextMenu->addAction(d->toggleAutoLevelsAction);
+
   d->contextMenu->addSection(QStringLiteral("Detections"));
 
   d->loadDetectionsAction = new QAction{"&Load Detections...", this};
@@ -114,9 +138,9 @@ Player::Player(Role role, QWidget* parent)
   connect(d->mergeDetectionsAction, &QAction::triggered,
           this, [this, d] { d->mergeSelectedTracks(this); });
 
-    d->contextMenu->addAction(d->loadDetectionsAction);
-    d->contextMenu->addAction(d->saveDetectionsAction);
-    d->contextMenu->addAction(d->mergeDetectionsAction);
+  d->contextMenu->addAction(d->loadDetectionsAction);
+  d->contextMenu->addAction(d->saveDetectionsAction);
+  d->contextMenu->addAction(d->mergeDetectionsAction);
 }
 
 // ----------------------------------------------------------------------------


### PR DESCRIPTION
Add actions to the Player context menus to allow toggling whether automatic levels (contrast mode == percentile) are used.