### PR TITLE
Allow changing text when no video is loaded

### DIFF
--- a/sealtk/gui/Player.cpp
+++ b/sealtk/gui/Player.cpp
@@ -231,6 +231,8 @@ public:
   QMatrix4x4 inverseHomography;
   QSize homographyImageSize;
 
+  QString noVideoText = QStringLiteral("Right-click to load imagery");
+
   QVector<float> detectedObjectVertexData;
   QVector<DetectionInfo> detectedObjectVertexIndices;
 
@@ -829,6 +831,13 @@ void Player::setHomographyImageSize(QSize size)
 }
 
 // ----------------------------------------------------------------------------
+void Player::setNoVideoText(QString const& text)
+{
+  QTE_D();
+  d->noVideoText = text;
+}
+
+// ----------------------------------------------------------------------------
 void Player::initializeGL()
 {
   QTE_D();
@@ -928,10 +937,9 @@ void Player::paintEvent(QPaintEvent* event)
   // Paint text overlay, if needed
   if (!d->image)
   {
-    static auto const noVideo = QStringLiteral("Right-click to load imagery");
     static auto const noFrame = QStringLiteral("(NO IMAGE)");
 
-    auto const& text = (d->videoSource ? noFrame : noVideo);
+    auto const& text = (d->videoSource ? noFrame : d->noVideoText);
 
     QPainter painter{this};
     painter.setPen(Qt::white);

--- a/sealtk/gui/Player.hpp
+++ b/sealtk/gui/Player.hpp
@@ -130,6 +130,8 @@ public slots:
 protected:
   QTE_DECLARE_PRIVATE(Player)
 
+  void setNoVideoText(QString const& text);
+
   void initializeGL() override;
   void paintGL() override;
   void resizeGL(int w, int h) override;


### PR DESCRIPTION
Add a method to `Player` to allow users (of the class, not necessarily of an application) to change the text that is displayed when no video is loaded. This is desirable as the default assumes that video will be loaded via a context menu, which may not be the case for all applications.